### PR TITLE
feat: add digit shortcut (1/2/3) for permission approval on Feishu/QQ

### DIFF
--- a/src/__tests__/unit/bridge-digit-shortcut-integration.test.ts
+++ b/src/__tests__/unit/bridge-digit-shortcut-integration.test.ts
@@ -1,0 +1,437 @@
+/**
+ * Integration tests for digit shortcut (1/2/3) permission flow.
+ *
+ * Tests the FULL end-to-end path:
+ *   permission card sent → shortcut registered → user replies "1" → permission resolved
+ *
+ * Also tests edge cases:
+ *   - "1" with no pending permission → falls through to conversation engine
+ *   - Expired shortcuts → falls through
+ *   - Shortcut overwrite when new permission arrives
+ */
+
+import { describe, it, beforeEach } from 'node:test';
+import assert from 'node:assert/strict';
+import { initBridgeContext } from '../../lib/bridge/context';
+import {
+  forwardPermissionRequest,
+  resolveShortcut,
+  handlePermissionCallback,
+  _testOnly,
+} from '../../lib/bridge/permission-broker';
+import type { BaseChannelAdapter } from '../../lib/bridge/channel-adapter';
+import type { BridgeStore, PermissionResolution } from '../../lib/bridge/host';
+import type { OutboundMessage, SendResult } from '../../lib/bridge/types';
+
+const { pendingShortcuts } = _testOnly;
+
+// ── Mock Store (with real permLink tracking) ─────────────────
+
+function createMockStore() {
+  const permLinks = new Map<string, {
+    permissionRequestId: string;
+    channelType: string;
+    chatId: string;
+    messageId: string;
+    toolName: string;
+    suggestions: string;
+    resolved: boolean;
+  }>();
+
+  return {
+    permLinks,
+    getSetting: () => null,
+    getChannelBinding: () => null,
+    upsertChannelBinding: () => ({}) as any,
+    updateChannelBinding: () => {},
+    listChannelBindings: () => [],
+    getSession: () => null,
+    createSession: () => ({ id: '1', working_directory: '', model: '' }),
+    updateSessionProviderId: () => {},
+    addMessage: () => {},
+    getMessages: () => ({ messages: [] }),
+    acquireSessionLock: () => true,
+    renewSessionLock: () => {},
+    releaseSessionLock: () => {},
+    setSessionRuntimeStatus: () => {},
+    updateSdkSessionId: () => {},
+    updateSessionModel: () => {},
+    syncSdkTasks: () => {},
+    getProvider: () => undefined,
+    getDefaultProviderId: () => null,
+    insertAuditLog: () => {},
+    checkDedup: () => false,
+    insertDedup: () => {},
+    cleanupExpiredDedup: () => {},
+    insertOutboundRef: () => {},
+    insertPermissionLink: (link: any) => {
+      permLinks.set(link.permissionRequestId, { ...link, resolved: false });
+    },
+    getPermissionLink: (id: string) => permLinks.get(id) ?? null,
+    markPermissionLinkResolved: (id: string) => {
+      const link = permLinks.get(id);
+      if (!link || link.resolved) return false;
+      link.resolved = true;
+      return true;
+    },
+    getChannelOffset: () => '0',
+    setChannelOffset: () => {},
+  };
+}
+
+// ── Mock Gateway ─────────────────────────────────────────────
+
+function createMockGateway() {
+  const resolved: Array<{ id: string; resolution: PermissionResolution }> = [];
+  return {
+    resolved,
+    resolvePendingPermission(id: string, resolution: PermissionResolution) {
+      resolved.push({ id, resolution });
+      return true;
+    },
+  };
+}
+
+// ── Mock Adapter (feishu-like, no inline buttons) ────────────
+
+function createMockFeishuAdapter(opts?: {
+  sendFn?: (msg: OutboundMessage) => Promise<SendResult>;
+}): BaseChannelAdapter {
+  const sendFn = opts?.sendFn ?? (async () => ({ ok: true, messageId: `msg-${Date.now()}` }));
+  return {
+    channelType: 'feishu',
+    start: async () => {},
+    stop: async () => {},
+    isRunning: () => true,
+    consumeOne: async () => null,
+    send: sendFn,
+    validateConfig: () => null,
+    isAuthorized: () => true,
+  } as unknown as BaseChannelAdapter;
+}
+
+function createMockQQAdapter(opts?: {
+  sendFn?: (msg: OutboundMessage) => Promise<SendResult>;
+}): BaseChannelAdapter {
+  const sendFn = opts?.sendFn ?? (async () => ({ ok: true, messageId: `msg-${Date.now()}` }));
+  return {
+    channelType: 'qq',
+    start: async () => {},
+    stop: async () => {},
+    isRunning: () => true,
+    consumeOne: async () => null,
+    send: sendFn,
+    validateConfig: () => null,
+    isAuthorized: () => true,
+  } as unknown as BaseChannelAdapter;
+}
+
+type MockStore = ReturnType<typeof createMockStore>;
+type MockGateway = ReturnType<typeof createMockGateway>;
+
+function setupContext(store: MockStore, gateway: MockGateway) {
+  delete (globalThis as Record<string, unknown>)['__bridge_context__'];
+  initBridgeContext({
+    store: store as unknown as BridgeStore,
+    llm: { streamChat: () => new ReadableStream() },
+    permissions: gateway,
+    lifecycle: {},
+  });
+}
+
+// ── Integration Tests ───────────────────────────────────────
+
+describe('digit shortcut integration - feishu', () => {
+  let store: MockStore;
+  let gateway: MockGateway;
+  let sentMessages: OutboundMessage[];
+  let adapter: BaseChannelAdapter;
+
+  beforeEach(() => {
+    store = createMockStore();
+    gateway = createMockGateway();
+    setupContext(store, gateway);
+    pendingShortcuts.clear();
+
+    sentMessages = [];
+    adapter = createMockFeishuAdapter({
+      sendFn: async (msg) => {
+        sentMessages.push(msg);
+        return { ok: true, messageId: `msg-${sentMessages.length}` };
+      },
+    });
+  });
+
+  it('full flow: forwardPermissionRequest → user replies "1" → allow resolved', async () => {
+    const address = { channelType: 'feishu' as const, chatId: 'chat-100', userId: 'user-1' };
+
+    // Step 1: Forward permission request (simulates Claude asking for tool approval)
+    await forwardPermissionRequest(
+      adapter, address, 'perm-id-001', 'Bash',
+      { command: 'ls -la' }, 'session-1', undefined, 'orig-msg-1',
+    );
+
+    // Verify: card was sent
+    assert.equal(sentMessages.length, 1);
+    assert.ok(sentMessages[0].text.includes('Permission Required'));
+
+    // Verify: shortcut was registered for this chat
+    assert.ok(pendingShortcuts.has('chat-100'), 'Shortcut should be registered');
+    const shortcut = pendingShortcuts.get('chat-100')!;
+    assert.equal(shortcut.permId, 'perm-id-001');
+
+    // Verify: permission link was stored in DB
+    assert.ok(store.permLinks.has('perm-id-001'));
+
+    // Step 2: User replies "1" → resolveShortcut
+    const result = resolveShortcut('chat-100', 1);
+    assert.ok(result.handled, 'Shortcut should be handled');
+    assert.equal(result.action, 'allow');
+
+    // Verify: gateway received the resolution
+    assert.equal(gateway.resolved.length, 1);
+    assert.equal(gateway.resolved[0].id, 'perm-id-001');
+    assert.equal(gateway.resolved[0].resolution.behavior, 'allow');
+
+    // Verify: shortcut was cleared
+    assert.equal(pendingShortcuts.has('chat-100'), false);
+
+    // Verify: permission link is marked resolved
+    assert.ok(store.permLinks.get('perm-id-001')!.resolved);
+  });
+
+  it('full flow: user replies "2" → allow_session resolved', async () => {
+    const address = { channelType: 'feishu' as const, chatId: 'chat-200', userId: 'user-1' };
+    const suggestions = [{ type: 'allow', toolName: 'Bash' }];
+
+    await forwardPermissionRequest(
+      adapter, address, 'perm-id-002', 'Bash',
+      { command: 'npm test' }, 'session-1', suggestions,
+    );
+
+    const result = resolveShortcut('chat-200', 2);
+    assert.ok(result.handled);
+    assert.equal(result.action, 'allow_session');
+    assert.equal(gateway.resolved[0].resolution.behavior, 'allow');
+    assert.ok((gateway.resolved[0].resolution as any).updatedPermissions);
+  });
+
+  it('full flow: user replies "3" → deny resolved', async () => {
+    const address = { channelType: 'feishu' as const, chatId: 'chat-300', userId: 'user-1' };
+
+    await forwardPermissionRequest(
+      adapter, address, 'perm-id-003', 'Write',
+      { file_path: '/etc/passwd' }, 'session-1',
+    );
+
+    const result = resolveShortcut('chat-300', 3);
+    assert.ok(result.handled);
+    assert.equal(result.action, 'deny');
+    assert.equal(gateway.resolved[0].resolution.behavior, 'deny');
+  });
+
+  it('no pending shortcut → resolveShortcut returns not handled', () => {
+    const result = resolveShortcut('chat-no-perm', 1);
+    assert.equal(result.handled, false);
+    assert.equal(result.action, undefined);
+  });
+
+  it('Telegram adapter does NOT register shortcuts (has inline buttons)', async () => {
+    const tgAdapter = {
+      channelType: 'telegram',
+      start: async () => {},
+      stop: async () => {},
+      isRunning: () => true,
+      consumeOne: async () => null,
+      send: async () => ({ ok: true, messageId: 'tg-msg-1' }),
+      validateConfig: () => null,
+      isAuthorized: () => true,
+    } as unknown as BaseChannelAdapter;
+
+    const address = { channelType: 'telegram' as const, chatId: 'tg-chat-1', userId: 'user-1' };
+
+    await forwardPermissionRequest(
+      tgAdapter, address, 'perm-id-tg', 'Bash',
+      { command: 'echo hi' }, 'session-1',
+    );
+
+    // Telegram should NOT have a shortcut registered
+    assert.equal(pendingShortcuts.has('tg-chat-1'), false);
+  });
+
+  it('new permission overwrites previous shortcut for same chat', async () => {
+    const address = { channelType: 'feishu' as const, chatId: 'chat-overwrite', userId: 'user-1' };
+
+    await forwardPermissionRequest(
+      adapter, address, 'perm-old', 'Bash',
+      { command: 'old' }, 'session-1',
+    );
+
+    await forwardPermissionRequest(
+      adapter, address, 'perm-new', 'Read',
+      { file_path: '/tmp/test' }, 'session-1',
+    );
+
+    // Shortcut should point to the new permission
+    const shortcut = pendingShortcuts.get('chat-overwrite')!;
+    assert.equal(shortcut.permId, 'perm-new');
+
+    // Resolving should affect the new permission
+    const result = resolveShortcut('chat-overwrite', 1);
+    assert.ok(result.handled);
+    assert.equal(gateway.resolved[0].id, 'perm-new');
+  });
+});
+
+describe('digit shortcut integration - qq', () => {
+  let store: MockStore;
+  let gateway: MockGateway;
+  let sentMessages: OutboundMessage[];
+  let adapter: BaseChannelAdapter;
+
+  beforeEach(() => {
+    store = createMockStore();
+    gateway = createMockGateway();
+    setupContext(store, gateway);
+    pendingShortcuts.clear();
+
+    sentMessages = [];
+    adapter = createMockQQAdapter({
+      sendFn: async (msg) => {
+        sentMessages.push(msg);
+        return { ok: true, messageId: `msg-${sentMessages.length}` };
+      },
+    });
+  });
+
+  it('QQ permission card includes digit shortcuts text', async () => {
+    const address = { channelType: 'qq' as const, chatId: 'qq-user-1', userId: 'qq-user-1' };
+
+    await forwardPermissionRequest(
+      adapter, address, 'perm-qq-1', 'Bash',
+      { command: 'ls' }, 'session-1', undefined, 'reply-to-1',
+    );
+
+    assert.equal(sentMessages.length, 1);
+    const cardText = sentMessages[0].text;
+    assert.ok(cardText.includes('1 - Allow'), 'Should include digit 1 shortcut');
+    assert.ok(cardText.includes('2 - Allow for this session'), 'Should include digit 2 shortcut');
+    assert.ok(cardText.includes('3 - Deny'), 'Should include digit 3 shortcut');
+    assert.ok(cardText.includes('/perm allow'), 'Should still include /perm command as fallback');
+  });
+
+  it('QQ registers shortcut and resolves via digit', async () => {
+    const address = { channelType: 'qq' as const, chatId: 'qq-chat-1', userId: 'qq-user-1' };
+
+    await forwardPermissionRequest(
+      adapter, address, 'perm-qq-2', 'Read',
+      { file_path: '/tmp/test' }, 'session-1',
+    );
+
+    assert.ok(pendingShortcuts.has('qq-chat-1'));
+
+    const result = resolveShortcut('qq-chat-1', 1);
+    assert.ok(result.handled);
+    assert.equal(result.action, 'allow');
+  });
+});
+
+describe('digit shortcut integration - bridge-manager handleMessage', () => {
+  let store: MockStore;
+  let gateway: MockGateway;
+
+  beforeEach(() => {
+    store = createMockStore();
+    gateway = createMockGateway();
+    setupContext(store, gateway);
+    pendingShortcuts.clear();
+    // Clean global bridge-manager state
+    delete (globalThis as Record<string, unknown>)['__bridge_manager__'];
+  });
+
+  it('handleMessage resolves digit "1" when pending shortcut exists', async () => {
+    const { _testOnly: bmTest } = await import('../../lib/bridge/bridge-manager');
+
+    // Setup: register a shortcut and permission link
+    const chatId = 'bm-chat-1';
+    store.permLinks.set('perm-bm-1', {
+      permissionRequestId: 'perm-bm-1',
+      channelType: 'feishu',
+      chatId,
+      messageId: 'orig-msg',
+      toolName: 'Bash',
+      suggestions: '',
+      resolved: false,
+    });
+    _testOnly.registerShortcut(chatId, 'perm-bm-1');
+
+    const sentMessages: OutboundMessage[] = [];
+    const adapter = createMockFeishuAdapter({
+      sendFn: async (msg) => {
+        sentMessages.push(msg);
+        return { ok: true, messageId: 'reply-1' };
+      },
+    });
+
+    // User sends "1"
+    await bmTest.handleMessage(adapter, {
+      messageId: 'user-msg-1',
+      address: { channelType: 'feishu' as const, chatId, userId: 'user-1' },
+      text: '1',
+      timestamp: Date.now(),
+    });
+
+    // Should have sent a confirmation
+    assert.equal(sentMessages.length, 1);
+    assert.ok(sentMessages[0].text.includes('Permission allow: recorded.'));
+
+    // Gateway should have resolved
+    assert.equal(gateway.resolved.length, 1);
+    assert.equal(gateway.resolved[0].resolution.behavior, 'allow');
+  });
+
+  it('handleMessage passes "1" to conversation engine when NO pending shortcut', async () => {
+    // Re-init context with a fast-closing LLM stream
+    delete (globalThis as Record<string, unknown>)['__bridge_context__'];
+    initBridgeContext({
+      store: store as unknown as BridgeStore,
+      llm: {
+        streamChat: () => new ReadableStream({
+          start(controller) {
+            controller.enqueue(`data: ${JSON.stringify({ type: 'text', data: 'Echo: 1' })}\n`);
+            controller.enqueue(`data: ${JSON.stringify({ type: 'result', data: JSON.stringify({ usage: { input_tokens: 1, output_tokens: 1 } }) })}\n`);
+            controller.close();
+          },
+        }),
+      },
+      permissions: gateway,
+      lifecycle: {},
+    });
+
+    const { _testOnly: bmTest } = await import('../../lib/bridge/bridge-manager');
+
+    const sentMessages: OutboundMessage[] = [];
+    const adapter = createMockFeishuAdapter({
+      sendFn: async (msg) => {
+        sentMessages.push(msg);
+        return { ok: true, messageId: 'reply-1' };
+      },
+    });
+
+    // User sends "1" but there is NO pending shortcut
+    await bmTest.handleMessage(adapter, {
+      messageId: 'user-msg-2',
+      address: { channelType: 'feishu' as const, chatId: 'bm-chat-no-perm', userId: 'user-1' },
+      text: '1',
+      timestamp: Date.now(),
+    });
+
+    // Should NOT have sent a permission confirmation
+    const permResponses = sentMessages.filter(m => m.text.includes('Permission'));
+    assert.equal(permResponses.length, 0, 'Should not respond with permission message when no shortcut');
+
+    // Should have sent the echo response instead (message passed through to LLM)
+    const echoResponses = sentMessages.filter(m => m.text.includes('Echo'));
+    assert.ok(echoResponses.length > 0, 'Should have passed message to conversation engine');
+  });
+});

--- a/src/__tests__/unit/bridge-permission-broker.test.ts
+++ b/src/__tests__/unit/bridge-permission-broker.test.ts
@@ -10,8 +10,10 @@
 import { describe, it, beforeEach } from 'node:test';
 import assert from 'node:assert/strict';
 import { initBridgeContext } from '../../lib/bridge/context';
-import { handlePermissionCallback } from '../../lib/bridge/permission-broker';
+import { handlePermissionCallback, resolveShortcut, _testOnly } from '../../lib/bridge/permission-broker';
 import type { BridgeStore, PermissionGateway, PermissionResolution } from '../../lib/bridge/host';
+
+const { registerShortcut, clearShortcut, pendingShortcuts } = _testOnly;
 
 // ── Mock Store ──────────────────────────────────────────────
 
@@ -197,5 +199,138 @@ describe('permission-broker', () => {
     assert.ok(result);
     assert.equal(gateway.resolved[0].resolution.behavior, 'allow');
     assert.ok((gateway.resolved[0].resolution as any).updatedPermissions);
+  });
+});
+
+// ── Digit Shortcut Tests ──────────────────────────────────────
+
+describe('permission-broker digit shortcuts', () => {
+  let store: MockStore;
+  let gateway: MockGateway;
+
+  beforeEach(() => {
+    store = createMockStore();
+    gateway = createMockGateway();
+    setupContext(store, gateway);
+    // Clear any leftover shortcuts from previous tests
+    pendingShortcuts.clear();
+  });
+
+  it('resolveShortcut returns not handled when no shortcut registered', () => {
+    const result = resolveShortcut('chat-1', 1);
+    assert.equal(result.handled, false);
+  });
+
+  it('resolveShortcut resolves digit 1 to allow', () => {
+    // Register a shortcut and matching permission link
+    store.links.set('perm-s1', {
+      chatId: 'chat-1',
+      messageId: 'msg-s1',
+      resolved: false,
+      suggestions: '',
+    });
+    registerShortcut('chat-1', 'perm-s1');
+
+    const result = resolveShortcut('chat-1', 1);
+    assert.ok(result.handled);
+    assert.equal(result.action, 'allow');
+    assert.equal(gateway.resolved.length, 1);
+    assert.equal(gateway.resolved[0].resolution.behavior, 'allow');
+  });
+
+  it('resolveShortcut resolves digit 2 to allow_session', () => {
+    store.links.set('perm-s2', {
+      chatId: 'chat-2',
+      messageId: 'msg-s2',
+      resolved: false,
+      suggestions: '',
+    });
+    registerShortcut('chat-2', 'perm-s2');
+
+    const result = resolveShortcut('chat-2', 2);
+    assert.ok(result.handled);
+    assert.equal(result.action, 'allow_session');
+  });
+
+  it('resolveShortcut resolves digit 3 to deny', () => {
+    store.links.set('perm-s3', {
+      chatId: 'chat-3',
+      messageId: 'msg-s3',
+      resolved: false,
+      suggestions: '',
+    });
+    registerShortcut('chat-3', 'perm-s3');
+
+    const result = resolveShortcut('chat-3', 3);
+    assert.ok(result.handled);
+    assert.equal(result.action, 'deny');
+    assert.equal(gateway.resolved[0].resolution.behavior, 'deny');
+  });
+
+  it('resolveShortcut clears shortcut after successful resolution', () => {
+    store.links.set('perm-s4', {
+      chatId: 'chat-4',
+      messageId: 'msg-s4',
+      resolved: false,
+      suggestions: '',
+    });
+    registerShortcut('chat-4', 'perm-s4');
+
+    resolveShortcut('chat-4', 1);
+    // Shortcut should be cleared
+    assert.equal(pendingShortcuts.has('chat-4'), false);
+  });
+
+  it('resolveShortcut returns not handled for expired shortcuts', () => {
+    store.links.set('perm-s5', {
+      chatId: 'chat-5',
+      messageId: 'msg-s5',
+      resolved: false,
+      suggestions: '',
+    });
+    registerShortcut('chat-5', 'perm-s5');
+
+    // Manually expire the shortcut
+    const shortcut = pendingShortcuts.get('chat-5')!;
+    shortcut.expireAt = Date.now() - 1;
+
+    const result = resolveShortcut('chat-5', 1);
+    assert.equal(result.handled, false);
+  });
+
+  it('new shortcut overwrites old one for same chat', () => {
+    store.links.set('perm-old', {
+      chatId: 'chat-6',
+      messageId: 'msg-old',
+      resolved: false,
+      suggestions: '',
+    });
+    store.links.set('perm-new', {
+      chatId: 'chat-6',
+      messageId: 'msg-new',
+      resolved: false,
+      suggestions: '',
+    });
+
+    registerShortcut('chat-6', 'perm-old');
+    registerShortcut('chat-6', 'perm-new');
+
+    const result = resolveShortcut('chat-6', 1);
+    assert.ok(result.handled);
+    // Should resolve the new permission, not the old one
+    assert.equal(gateway.resolved[0].id, 'perm-new');
+  });
+
+  it('resolveShortcut returns not handled for invalid digit', () => {
+    store.links.set('perm-s7', {
+      chatId: 'chat-7',
+      messageId: 'msg-s7',
+      resolved: false,
+      suggestions: '',
+    });
+    registerShortcut('chat-7', 'perm-s7');
+
+    const result = resolveShortcut('chat-7', 4);
+    assert.equal(result.handled, false);
   });
 });

--- a/src/lib/bridge/adapters/feishu-adapter.ts
+++ b/src/lib/bridge/adapters/feishu-adapter.ts
@@ -373,24 +373,29 @@ export class FeishuAdapter extends BaseChannelAdapter {
       return { ok: false, error: 'Feishu client not initialized' };
     }
 
-    // Build /perm command lines from inline buttons
+    // Build digit shortcut lines + collapsible /perm commands
     const permCommands = inlineButtons.flat().map((btn) => {
       if (btn.callbackData.startsWith('perm:')) {
         const parts = btn.callbackData.split(':');
         const action = parts[1];
         const permId = parts.slice(2).join(':');
-        return `\`/perm ${action} ${permId}\``;
+        return `/perm ${action} ${permId}`;
       }
       return btn.text;
     });
 
-    // Schema 2.0 card with markdown — permission info + copyable commands
+    // Schema 2.0 card with markdown — digit shortcuts + fallback commands
     const cardContent = [
       text,
       '',
       '---',
-      '**Reply with one of these commands:**',
-      ...permCommands,
+      '**Reply with:**',
+      '**1** - Allow',
+      '**2** - Allow for this session',
+      '**3** - Deny',
+      '',
+      '*Or use commands:*',
+      ...permCommands.map((cmd) => `\`${cmd}\``),
     ].join('\n');
 
     const cardJson = JSON.stringify({
@@ -424,15 +429,8 @@ export class FeishuAdapter extends BaseChannelAdapter {
       console.warn('[feishu-adapter] Permission card error:', err instanceof Error ? err.message : err);
     }
 
-    // Fallback: plain text
-    const plainCommands = inlineButtons.flat().map((btn) => {
-      if (btn.callbackData.startsWith('perm:')) {
-        const parts = btn.callbackData.split(':');
-        return `/perm ${parts[1]} ${parts.slice(2).join(':')}`;
-      }
-      return btn.text;
-    });
-    const fallbackText = text + '\n\nReply with:\n' + plainCommands.join('\n');
+    // Fallback: plain text with digit shortcuts
+    const fallbackText = text + '\n\nReply with:\n1 - Allow\n2 - Allow for this session\n3 - Deny\n\nOr use commands:\n' + permCommands.join('\n');
 
     try {
       const res = await this.restClient.im.message.create({

--- a/src/lib/bridge/bridge-manager.ts
+++ b/src/lib/bridge/bridge-manager.ts
@@ -468,6 +468,24 @@ async function handleMessage(
     return;
   }
 
+  // Check for digit shortcut (1/2/3) for quick permission response.
+  // Only intercept if there IS a pending shortcut — otherwise fall through
+  // to conversation engine so the user's message is not lost.
+  if (/^[123]$/.test(rawText)) {
+    const result = broker.resolveShortcut(msg.address.chatId, parseInt(rawText, 10));
+    if (result.handled) {
+      await deliver(adapter, {
+        address: msg.address,
+        text: `Permission ${result.action}: recorded.`,
+        parseMode: 'plain',
+        replyToMessageId: msg.messageId,
+      });
+      ack();
+      return;
+    }
+    // No pending permission — fall through to conversation engine
+  }
+
   // Sanitize general message text before routing to conversation engine
   const { text, truncated } = sanitizeInput(rawText);
   if (truncated) {

--- a/src/lib/bridge/permission-broker.ts
+++ b/src/lib/bridge/permission-broker.ts
@@ -23,6 +23,71 @@ import { escapeHtml } from './adapters/telegram-utils.js';
 const recentPermissionForwards = new Map<string, number>();
 
 /**
+ * Per-chat pending permission shortcut mapping.
+ * When a permission card is sent, we register a shortcut so users can
+ * reply with 1/2/3 instead of typing the full /perm command.
+ * Each chat keeps only the latest pending permission (new overwrites old).
+ */
+interface PendingShortcut {
+  permId: string;
+  actions: readonly ['allow', 'allow_session', 'deny'];
+  expireAt: number;
+}
+
+const SHORTCUT_TTL_MS = 5 * 60 * 1000; // 5 minutes
+const pendingShortcuts = new Map<string, PendingShortcut>();
+
+/**
+ * Register a digit shortcut mapping for a chat after sending a permission card.
+ */
+function registerShortcut(chatId: string, permId: string): void {
+  pendingShortcuts.set(chatId, {
+    permId,
+    actions: ['allow', 'allow_session', 'deny'],
+    expireAt: Date.now() + SHORTCUT_TTL_MS,
+  });
+}
+
+/**
+ * Clear the pending shortcut for a chat (called after resolution).
+ */
+function clearShortcut(chatId: string): void {
+  pendingShortcuts.delete(chatId);
+}
+
+/**
+ * Resolve a digit shortcut (1/2/3) for a given chat.
+ * Returns the result of handlePermissionCallback if a mapping exists.
+ */
+export function resolveShortcut(
+  chatId: string,
+  digit: number,
+): { handled: boolean; action?: string } {
+  const shortcut = pendingShortcuts.get(chatId);
+  if (!shortcut) return { handled: false };
+
+  // Check expiry
+  if (Date.now() > shortcut.expireAt) {
+    pendingShortcuts.delete(chatId);
+    return { handled: false };
+  }
+
+  // digit is 1-indexed, actions array is 0-indexed
+  const action = shortcut.actions[digit - 1];
+  if (!action) return { handled: false };
+
+  const callbackData = `perm:${action}:${shortcut.permId}`;
+  const resolved = handlePermissionCallback(callbackData, chatId);
+
+  if (resolved) {
+    clearShortcut(chatId);
+    return { handled: true, action };
+  }
+
+  return { handled: false };
+}
+
+/**
  * Forward a permission request to an IM channel as an interactive message.
  */
 export async function forwardPermissionRequest(
@@ -60,14 +125,19 @@ export async function forwardPermissionRequest(
   let result: import('./types.js').SendResult;
 
   if (adapter.channelType === 'qq') {
-    // QQ: plain text permission prompt with copyable /perm commands (no inline buttons)
+    // QQ: plain text permission prompt with digit shortcuts (no inline buttons)
     const qqText = [
       `Permission Required`,
       ``,
       `Tool: ${toolName}`,
       truncatedInput,
       ``,
-      `Reply with one of:`,
+      `Reply with:`,
+      `1 - Allow`,
+      `2 - Allow for this session`,
+      `3 - Deny`,
+      ``,
+      `Or use commands:`,
       `/perm allow ${permissionRequestId}`,
       `/perm allow_session ${permissionRequestId}`,
       `/perm deny ${permissionRequestId}`,
@@ -120,6 +190,11 @@ export async function forwardPermissionRequest(
         suggestions: suggestions ? JSON.stringify(suggestions) : '',
       });
     } catch { /* best effort */ }
+
+    // Register digit shortcut for non-Telegram channels (Telegram has inline buttons)
+    if (adapter.channelType !== 'telegram') {
+      registerShortcut(address.chatId, permissionRequestId);
+    }
   }
 }
 
@@ -224,3 +299,7 @@ export function handlePermissionCallback(
 
   return resolved;
 }
+
+// ── Test-only exports ────────────────────────────────────────
+/** @internal */
+export const _testOnly = { registerShortcut, clearShortcut, pendingShortcuts };


### PR DESCRIPTION
Feishu and QQ do not support clickable inline buttons (unlike Telegram). Previously users had to manually type long `/perm allow <permId>` commands to approve permissions, which is very inconvenient on mobile devices.

Now users can simply reply with 1, 2, or 3:
  1 - Allow
  2 - Allow for this session
  3 - Deny

Design:
- permission-broker maintains a per-chat pendingShortcuts Map (TTL 5min)
- When a permission card is sent on non-Telegram channels, a shortcut mapping is registered for that chatId
- bridge-manager intercepts digit messages (1/2/3) ONLY when a pending shortcut exists; otherwise the message passes through to Claude normally
- /perm commands are preserved as a fallback

Changes:
- permission-broker.ts: add pendingShortcuts Map, registerShortcut(), clearShortcut(), and exported resolveShortcut() function
- feishu-adapter.ts: update permission card text to show digit shortcuts prominently with /perm commands as secondary option
- bridge-manager.ts: add digit interception in handleMessage() that calls resolveShortcut() before the conversation engine
- QQ permission card text also updated with digit shortcuts

Safety:
- Shortcuts expire after 5 minutes (TTL)
- Each chat keeps only the latest pending permission (new overwrites old)
- Digits only intercepted when pending shortcut exists (no message loss)
- Telegram unaffected (uses real inline buttons, no shortcut registered)

Tests: 20 new tests (8 unit + 10 integration + 2 bridge-manager e2e) All 70 tests pass, 0 regressions.