### PR TITLE
fix: 校验 workingDirectory 存在性，防止 spawn 报误导性 ENOENT

### DIFF
--- a/src/lib/bridge/conversation-engine.ts
+++ b/src/lib/bridge/conversation-engine.ts
@@ -157,13 +157,24 @@ export async function processMessage(
       }
     }
 
+    // workingDirectory 不存在时，SDK spawn 会报误导性的 ENOENT（看起来像是可执行文件找不到）
+    // 这里做校验并 fallback，避免难以排查的错误
+    let workingDirectory = binding.workingDirectory || session?.working_directory || undefined;
+    if (workingDirectory && !fs.existsSync(workingDirectory)) {
+      const fallback = process.env.CTI_DEFAULT_WORKDIR || process.cwd();
+      console.warn(
+        `[conversation-engine] workingDirectory "${workingDirectory}" does not exist, falling back to "${fallback}"`,
+      );
+      workingDirectory = fallback;
+    }
+
     const stream = llm.streamChat({
       prompt: text,
       sessionId,
       sdkSessionId: binding.sdkSessionId || undefined,
       model: effectiveModel,
       systemPrompt: session?.system_prompt || undefined,
-      workingDirectory: binding.workingDirectory || session?.working_directory || undefined,
+      workingDirectory,
       abortController,
       permissionMode,
       provider: resolvedProvider,


### PR DESCRIPTION
## Summary

修复 `conversation-engine.ts` 中缺少 `workingDirectory` 存在性校验的问题。

## Problem

当 channel binding 的 `workingDirectory` 指向一个已删除的目录时，SDK `query()` 内部调用 `child_process.spawn()` 会报：

```
Error: Failed to spawn Claude Code process: spawn /opt/homebrew/bin/claude ENOENT
```

这是 Node.js 的已知行为：`cwd` 不存在时，`spawn()` 的 ENOENT 错误会显示 executable 路径而非 cwd 路径，极其误导。

## Fix

在调用 `llm.streamChat()` 前校验 `workingDirectory` 是否存在，不存在时 fallback 到 `CTI_DEFAULT_WORKDIR` 或 `process.cwd()`，并输出警告日志。

## Testing

1. 设置一个 binding 的 `workingDirectory` 为不存在的路径
2. 发送消息 → 修复前报 ENOENT，修复后自动 fallback 并正常响应

Closes #7

🤖 Generated with [Claude Code](https://claude.com/claude-code)