### PR TITLE
feat: add /model command and forward unknown slash commands to LLM

### DIFF
--- a/src/lib/bridge/bridge-manager.ts
+++ b/src/lib/bridge/bridge-manager.ts
@@ -548,9 +548,14 @@ async function handleMessage(
 
   // Check for IM commands (before sanitization — commands are validated individually)
   if (rawText.startsWith('/')) {
-    await handleCommand(adapter, msg, rawText);
-    ack();
-    return;
+    const handled = await handleCommand(adapter, msg, rawText);
+    if (handled) {
+      ack();
+      return;
+    }
+    // Unrecognized slash commands fall through as regular messages to the LLM.
+    // This allows Claude Code commands (/model, /compact, /clear, /doctor)
+    // and skill invocations to pass through.
   }
 
   // Sanitize general message text before routing to conversation engine
@@ -757,12 +762,14 @@ async function handleMessage(
 
 /**
  * Handle IM slash commands.
+ * Returns true if the command was handled, false if it should be
+ * forwarded to the LLM as a regular message.
  */
 async function handleCommand(
   adapter: BaseChannelAdapter,
   msg: InboundMessage,
   text: string,
-): Promise<void> {
+): Promise<boolean> {
   const { store } = getBridgeContext();
 
   // Extract command and args (handle /command@botname format)
@@ -804,6 +811,7 @@ async function handleCommand(
         '/bind &lt;session_id&gt; - Bind to existing session',
         '/cwd /path - Change working directory',
         '/mode plan|code|ask - Change mode',
+        '/model <name> - Switch model',
         '/status - Show current status',
         '/sessions - List recent sessions',
         '/stop - Stop current session',
@@ -881,6 +889,18 @@ async function handleCommand(
       break;
     }
 
+    case '/model': {
+      if (!args) {
+        const binding = router.resolve(msg.address);
+        response = `Current model: <code>${binding.model || 'default'}</code>\nUsage: /model <name> (e.g. /model claude-sonnet-4-20250514)`;
+        break;
+      }
+      const binding = router.resolve(msg.address);
+      router.updateBinding(binding.id, { model: args });
+      response = `Model set to <code>${escapeHtml(args)}</code>`;
+      break;
+    }
+
     case '/status': {
       const binding = router.resolve(msg.address);
       response = [
@@ -952,6 +972,7 @@ async function handleCommand(
         '/cwd /path - Change working directory',
         '/mode plan|code|ask - Change mode',
         '/status - Show current status',
+        '/model <name> - Switch model',
         '/sessions - List recent sessions',
         '/stop - Stop current session',
         '/perm allow|allow_session|deny &lt;id&gt; - Respond to permission request',
@@ -961,7 +982,8 @@ async function handleCommand(
       break;
 
     default:
-      response = `Unknown command: ${escapeHtml(command)}\nType /help for available commands.`;
+      // Unrecognized — let caller forward as regular message to LLM
+      return false;
   }
 
   if (response) {
@@ -972,6 +994,7 @@ async function handleCommand(
       replyToMessageId: msg.messageId,
     });
   }
+  return true;
 }
 
 // ── SDK Session Update Logic ─────────────────────────────────


### PR DESCRIPTION
## Summary

Addresses [Claude-to-IM-skill#46](https://github.com/op7418/Claude-to-IM-skill/issues/46) and [Claude-to-IM-skill#51](https://github.com/op7418/Claude-to-IM-skill/issues/51).

### Problem

1. **#46**: Users cannot switch models via IM — `/model gemini-3-flash` returns "Unknown command"
2. **#51**: All messages starting with `/` are intercepted as bridge commands, so Claude Code's own slash commands (`/compact`, `/clear`, `/doctor`) and skill invocations never reach the LLM

### Changes

**1. Add `/model` command**

```
/model claude-sonnet-4-20250514    → Switch to specified model
/model                        → Show current model
```

Updates the binding's `model` field, which is passed to Claude Code on the next message.

**2. Forward unrecognized slash commands**

`handleCommand` now returns `boolean`:
- `true` — command was handled by the bridge (e.g., `/new`, `/mode`, `/model`)
- `false` — unrecognized, falls through to regular message processing

This allows Claude Code built-in commands and skill invocations to pass through the bridge transparently.

### Help text

Updated both `/start` and `/help` responses to include `/model`.