### PR TITLE
feat: add bypass permissions mode for headless/IM usage

### DIFF
--- a/src/lib/bridge/bridge-manager.ts
+++ b/src/lib/bridge/bridge-manager.ts
@@ -803,7 +803,7 @@ async function handleCommand(
         '/new [path] - Start new session',
         '/bind &lt;session_id&gt; - Bind to existing session',
         '/cwd /path - Change working directory',
-        '/mode plan|code|ask - Change mode',
+        '/mode plan|code|ask|bypass - Change mode',
         '/status - Show current status',
         '/sessions - List recent sessions',
         '/stop - Stop current session',
@@ -872,7 +872,7 @@ async function handleCommand(
 
     case '/mode': {
       if (!validateMode(args)) {
-        response = 'Usage: /mode plan|code|ask';
+        response = 'Usage: /mode plan|code|ask|bypass';
         break;
       }
       const binding = router.resolve(msg.address);
@@ -950,7 +950,7 @@ async function handleCommand(
         '/new [path] - Start new session',
         '/bind &lt;session_id&gt; - Bind to existing session',
         '/cwd /path - Change working directory',
-        '/mode plan|code|ask - Change mode',
+        '/mode plan|code|ask|bypass - Change mode',
         '/status - Show current status',
         '/sessions - List recent sessions',
         '/stop - Stop current session',

--- a/src/lib/bridge/conversation-engine.ts
+++ b/src/lib/bridge/conversation-engine.ts
@@ -145,6 +145,7 @@ export async function processMessage(
     switch (binding.mode) {
       case 'plan': permissionMode = 'plan'; break;
       case 'ask': permissionMode = 'default'; break;
+      case 'bypass': permissionMode = 'bypassPermissions'; break;
       default: permissionMode = 'acceptEdits'; break;
     }
 

--- a/src/lib/bridge/security/validators.ts
+++ b/src/lib/bridge/security/validators.ts
@@ -12,7 +12,7 @@ import * as path from 'path';
 const MAX_INPUT_LENGTH = 32_000; // Claude's effective context limit
 const MAX_PATH_LENGTH = 1024;
 const SESSION_ID_PATTERN = /^[0-9a-f-]{32,64}$/i;
-const VALID_MODES = ['plan', 'code', 'ask'] as const;
+const VALID_MODES = ['plan', 'code', 'ask', 'bypass'] as const;
 
 /**
  * Patterns that indicate shell injection or dangerous input.
@@ -122,6 +122,6 @@ export function sanitizeInput(
 /**
  * Validate /mode parameter.
  */
-export function validateMode(mode: string): mode is 'plan' | 'code' | 'ask' {
+export function validateMode(mode: string): mode is 'plan' | 'code' | 'ask' | 'bypass' {
   return VALID_MODES.includes(mode as typeof VALID_MODES[number]);
 }

--- a/src/lib/bridge/types.ts
+++ b/src/lib/bridge/types.ts
@@ -100,7 +100,7 @@ export interface ChannelBinding {
   /** Model override for this binding */
   model: string;
   /** Chat mode */
-  mode: 'code' | 'plan' | 'ask';
+  mode: 'code' | 'plan' | 'ask' | 'bypass';
   /** Whether this binding is currently active */
   active: boolean;
   createdAt: string;


### PR DESCRIPTION
## Summary

The Claude Code SDK supports `bypassPermissions` as a valid `PermissionMode`, but the bridge only exposes `code`, `plan`, and `ask`. This means users operating via IM — where interactive permission prompts are painful or impossible (especially on mobile) — have no way to run Claude in fully autonomous mode.

This PR adds a new `bypass` mode that maps to the SDK's `bypassPermissions` permission mode.

## Changes

| File | Change |
|------|--------|
| `types.ts` | Add `'bypass'` to `ChannelBinding.mode` union type |
| `security/validators.ts` | Add `'bypass'` to `VALID_MODES` and `validateMode()` return type |
| `conversation-engine.ts` | Add `case 'bypass': permissionMode = 'bypassPermissions'` mapping |
| `bridge-manager.ts` | Update `/mode` help text in `/start`, `/help`, and usage error |

## Usage

```
/mode bypass          # Switch current session to bypass mode
/mode code            # Switch back to normal mode
```

Or set `bridge_default_mode=bypass` in host settings for new sessions.

**Note:** The host LLM provider is responsible for also passing `allowDangerouslySkipPermissions: true` to the SDK when it receives `bypassPermissions` as the permission mode — this is the SDK's safety interlock.

## Backward Compatibility

- Fully backward-compatible: existing `code`, `plan`, `ask` modes are unchanged
- New mode is opt-in only
- No changes to the default behavior

## Test Plan

- [x] Verified `/mode bypass` sets binding mode correctly
- [x] Verified `conversation-engine` maps bypass → `bypassPermissions`
- [x] Verified existing modes (`code`, `plan`, `ask`) are unaffected
- [x] Verified `/mode invalid` still returns usage error with updated text