### PR TITLE
fix: use persistent store dedup for inbound messages

### DIFF
--- a/src/lib/bridge/adapters/discord-adapter.ts
+++ b/src/lib/bridge/adapters/discord-adapter.ts
@@ -23,8 +23,7 @@ import type { FileAttachment } from '../types.js';
 import { BaseChannelAdapter, registerAdapterFactory } from '../channel-adapter.js';
 import { getBridgeContext } from '../context.js';
 
-/** Max number of message IDs to keep for dedup. */
-const DEDUP_MAX = 1000;
+
 
 /** Discord message character limit. */
 const DISCORD_CHAR_LIMIT = 2000;
@@ -60,7 +59,7 @@ export class DiscordAdapter extends BaseChannelAdapter {
   private client: any = null;
   private queue: InboundMessage[] = [];
   private waiters: Array<(msg: InboundMessage | null) => void> = [];
-  private seenMessageIds = new Set<string>();
+  // Inbound dedup now uses persistent store (survives process restarts)
   private botUserId: string | null = null;
   private typingIntervals = new Map<string, ReturnType<typeof setInterval>>();
   /** Temporary storage for Interaction objects (for answerCallback). */
@@ -158,7 +157,6 @@ export class DiscordAdapter extends BaseChannelAdapter {
     this.typingIntervals.clear();
 
     // Clear state
-    this.seenMessageIds.clear();
     this.pendingInteractions.clear();
     this.previewMessages.clear();
     this.previewDegraded.clear();
@@ -421,9 +419,10 @@ export class DiscordAdapter extends BaseChannelAdapter {
     if (message.author.bot) return;
     if (this.botUserId && message.author.id === this.botUserId) return;
 
-    // Dedup by message ID
-    if (this.seenMessageIds.has(message.id)) return;
-    this.addToDedup(message.id);
+    // Dedup by message ID — persistent via store (survives process restarts)
+    const store = getBridgeContext().store;
+    if (store.checkDedup(message.id)) return;
+    store.insertDedup(message.id);
 
     const chatId = message.channelId;
     const userId = message.author.id;
@@ -615,19 +614,7 @@ export class DiscordAdapter extends BaseChannelAdapter {
 
   // ── Utilities ───────────────────────────────────────────────
 
-  private addToDedup(messageId: string): void {
-    this.seenMessageIds.add(messageId);
-
-    if (this.seenMessageIds.size > DEDUP_MAX) {
-      const excess = this.seenMessageIds.size - DEDUP_MAX;
-      let removed = 0;
-      for (const id of this.seenMessageIds) {
-        if (removed >= excess) break;
-        this.seenMessageIds.delete(id);
-        removed++;
-      }
-    }
-  }
+  // addToDedup removed — now using persistent store.insertDedup()
 
   private cleanupExpiredInteractions(): void {
     const now = Date.now();

--- a/src/lib/bridge/adapters/feishu-adapter.ts
+++ b/src/lib/bridge/adapters/feishu-adapter.ts
@@ -39,8 +39,7 @@ import {
   formatElapsed,
 } from '../markdown/feishu.js';
 
-/** Max number of message_ids to keep for dedup. */
-const DEDUP_MAX = 1000;
+
 
 /** Max file download size (20 MB). */
 const MAX_FILE_SIZE = 20 * 1024 * 1024;
@@ -108,7 +107,7 @@ export class FeishuAdapter extends BaseChannelAdapter {
   private waiters: Array<(msg: InboundMessage | null) => void> = [];
   private wsClient: lark.WSClient | null = null;
   private restClient: lark.Client | null = null;
-  private seenMessageIds = new Map<string, boolean>();
+  // Inbound dedup now uses persistent store (survives process restarts)
   private botOpenId: string | null = null;
   /** All known bot IDs (open_id, user_id, union_id) for mention matching. */
   private botIds = new Set<string>();
@@ -224,7 +223,6 @@ export class FeishuAdapter extends BaseChannelAdapter {
     this.cardCreatePromises.clear();
 
     // Clear state
-    this.seenMessageIds.clear();
     this.lastIncomingMessageId.clear();
     this.typingReactions.clear();
 
@@ -921,9 +919,10 @@ export class FeishuAdapter extends BaseChannelAdapter {
     // [P1] Filter out bot messages to prevent self-triggering loops
     if (sender.sender_type === 'bot') return;
 
-    // Dedup by message_id
-    if (this.seenMessageIds.has(msg.message_id)) return;
-    this.addToDedup(msg.message_id);
+    // Dedup by message_id — persistent via store (survives process restarts)
+    const store = getBridgeContext().store;
+    if (store.checkDedup(msg.message_id)) return;
+    store.insertDedup(msg.message_id);
 
     const chatId = msg.chat_id;
     // [P2] Complete sender ID fallback chain: open_id > user_id > union_id
@@ -1347,20 +1346,7 @@ export class FeishuAdapter extends BaseChannelAdapter {
 
   // ── Utilities ───────────────────────────────────────────────
 
-  private addToDedup(messageId: string): void {
-    this.seenMessageIds.set(messageId, true);
-
-    // LRU eviction: remove oldest entries when exceeding limit
-    if (this.seenMessageIds.size > DEDUP_MAX) {
-      const excess = this.seenMessageIds.size - DEDUP_MAX;
-      let removed = 0;
-      for (const key of this.seenMessageIds.keys()) {
-        if (removed >= excess) break;
-        this.seenMessageIds.delete(key);
-        removed++;
-      }
-    }
-  }
+  // addToDedup removed — now using persistent store.insertDedup()
 }
 
 // Self-register so bridge-manager can create FeishuAdapter via the registry.

--- a/src/lib/bridge/adapters/qq-adapter.ts
+++ b/src/lib/bridge/adapters/qq-adapter.ts
@@ -43,7 +43,7 @@ export class QQAdapter extends BaseChannelAdapter {
   private heartbeatTimer: ReturnType<typeof setInterval> | null = null;
   private lastSequence: number | null = null;
   private sessionId: string | null = null;
-  private seenMessageIds = new Map<string, boolean>();
+  // Inbound dedup now uses persistent store (survives process restarts)
   private reconnectAttempts = 0;
   private maxReconnectAttempts = 10;
   private shouldReconnect = false;
@@ -97,7 +97,6 @@ export class QQAdapter extends BaseChannelAdapter {
     }
     this.waiters = [];
     this.queue = [];
-    this.seenMessageIds.clear();
 
     console.log('[qq-adapter] Stopped');
   }
@@ -294,20 +293,10 @@ export class QQAdapter extends BaseChannelAdapter {
   private handleC2CMessage(data: QQC2CMessageData): void {
     if (!data?.id || !data?.author?.user_openid) return;
 
-    // Dedup
-    if (this.seenMessageIds.has(data.id)) return;
-    this.seenMessageIds.set(data.id, true);
-
-    // Evict oldest when exceeding limit
-    if (this.seenMessageIds.size > 1000) {
-      const excess = this.seenMessageIds.size - 1000;
-      let removed = 0;
-      for (const key of this.seenMessageIds.keys()) {
-        if (removed >= excess) break;
-        this.seenMessageIds.delete(key);
-        removed++;
-      }
-    }
+    // Dedup — persistent via store (survives process restarts)
+    const store = getBridgeContext().store;
+    if (store.checkDedup(data.id)) return;
+    store.insertDedup(data.id);
 
     const userId = data.author.user_openid;
 


### PR DESCRIPTION
## Summary

- **Feishu, Discord, and QQ adapters** used in-memory `Map`/`Set` for inbound message dedup — lost on process restart
- On restart, replayed messages (e.g. Feishu WebSocket reconnect buffers) were all re-processed as new, causing duplicate handling
- The `BridgeStore` interface already provides persistent `checkDedup()` / `insertDedup()` (used by `delivery-layer` for outbound), but **inbound never used them**
- This PR switches all three adapters to use the persistent store dedup, making message deduplication survive process restarts
- Telegram is unaffected (uses `update_id` offset mechanism)

## Root cause

```
FeishuAdapter.seenMessageIds = new Map()  // in-memory, cleared on restart
→ process restart
→ WebSocket reconnects, Feishu replays un-ACKed messages
→ Map is empty, all replayed messages treated as new
→ duplicate processing
```

## Changes

| File | Before | After |
|------|--------|-------|
| `feishu-adapter.ts` | `seenMessageIds` Map | `store.checkDedup()` + `store.insertDedup()` |
| `discord-adapter.ts` | `seenMessageIds` Set | `store.checkDedup()` + `store.insertDedup()` |
| `qq-adapter.ts` | `seenMessageIds` Map | `store.checkDedup()` + `store.insertDedup()` |

## Test plan

- [x] Verified on Feishu: restart bridge, confirm replayed messages are correctly deduped
- [x] Confirmed `dedup.json` is created and persisted across restarts
- [ ] Discord / QQ adapters: same pattern, untested (no environment available)

🤖 Generated with [Claude Code](https://claude.com/claude-code)