### PR TITLE
feat: 添加微信 WeChat adapter（基于 ClawBot ilink API）

### DIFF
--- a/src/lib/bridge/adapters/index.ts
+++ b/src/lib/bridge/adapters/index.ts
@@ -13,3 +13,4 @@ import './telegram-adapter.js';
 import './feishu-adapter.js';
 import './discord-adapter.js';
 import './qq-adapter.js';
+import './wechat-adapter.js';

--- a/src/lib/bridge/adapters/wechat-adapter.ts
+++ b/src/lib/bridge/adapters/wechat-adapter.ts
@@ -1,0 +1,297 @@
+/**
+ * WeChat Bot Adapter — implements BaseChannelAdapter for WeChat ClawBot ilink API.
+ *
+ * Private chat via ClawBot. Supports text + voice-to-text inbound messages
+ * and text-only outbound.
+ *
+ * Uses HTTP long-polling (ilink/bot/getupdates) for real-time events
+ * and REST API (ilink/bot/sendmessage) for sending replies.
+ *
+ * Token is obtained via QR code scan during setup and stored in bridge settings.
+ */
+
+import crypto from 'crypto';
+import type {
+  ChannelType,
+  InboundMessage,
+  OutboundMessage,
+  SendResult,
+} from '../types.js';
+import { BaseChannelAdapter, registerAdapterFactory } from '../channel-adapter.js';
+import { getBridgeContext } from '../context.js';
+import {
+  getUpdates,
+  sendTextMessage,
+  extractTextFromMessage,
+  cacheContextToken,
+  getCachedContextToken,
+  clearContextTokenCache,
+  MSG_TYPE_USER,
+  DEFAULT_BASE_URL,
+} from './wechat-api.js';
+
+const MAX_CONSECUTIVE_FAILURES = 3;
+const BACKOFF_DELAY_MS = 30_000;
+const RETRY_DELAY_MS = 2_000;
+
+export class WeChatAdapter extends BaseChannelAdapter {
+  readonly channelType: ChannelType = 'wechat';
+
+  private _running = false;
+  private queue: InboundMessage[] = [];
+  private waiters: Array<(msg: InboundMessage | null) => void> = [];
+  private seenMessageIds = new Set<string>();
+  private pollAbort: AbortController | null = null;
+  private getUpdatesBuf = '';
+
+  // ── Lifecycle ───────────────────────────────────────────────
+
+  async start(): Promise<void> {
+    if (this._running) return;
+
+    const configError = this.validateConfig();
+    if (configError) {
+      console.warn('[wechat-adapter] Cannot start:', configError);
+      return;
+    }
+
+    this._running = true;
+    this.pollAbort = new AbortController();
+
+    // Start long-poll loop in background
+    this.runPollLoop();
+
+    console.log('[wechat-adapter] Started');
+  }
+
+  async stop(): Promise<void> {
+    if (!this._running) return;
+    this._running = false;
+
+    if (this.pollAbort) {
+      this.pollAbort.abort();
+      this.pollAbort = null;
+    }
+
+    // Wake all waiters with null
+    for (const waiter of this.waiters) {
+      waiter(null);
+    }
+    this.waiters = [];
+    this.queue = [];
+    this.seenMessageIds.clear();
+    clearContextTokenCache();
+
+    console.log('[wechat-adapter] Stopped');
+  }
+
+  isRunning(): boolean {
+    return this._running;
+  }
+
+  // ── Queue ───────────────────────────────────────────────────
+
+  consumeOne(): Promise<InboundMessage | null> {
+    const queued = this.queue.shift();
+    if (queued) return Promise.resolve(queued);
+
+    if (!this._running) return Promise.resolve(null);
+
+    return new Promise<InboundMessage | null>((resolve) => {
+      this.waiters.push(resolve);
+    });
+  }
+
+  private enqueue(msg: InboundMessage): void {
+    const waiter = this.waiters.shift();
+    if (waiter) {
+      waiter(msg);
+    } else {
+      this.queue.push(msg);
+    }
+  }
+
+  // ── Send ────────────────────────────────────────────────────
+
+  async send(message: OutboundMessage): Promise<SendResult> {
+    const store = getBridgeContext().store;
+    const token = store.getSetting('bridge_wechat_token') || '';
+    const baseUrl = store.getSetting('bridge_wechat_base_url') || DEFAULT_BASE_URL;
+
+    const contextToken = getCachedContextToken(message.address.chatId);
+    if (!contextToken) {
+      return {
+        ok: false,
+        error: `No context_token for ${message.address.chatId}. The user needs to send a message first.`,
+      };
+    }
+
+    // Strip HTML tags — WeChat doesn't render HTML
+    let content = message.text;
+    if (message.parseMode === 'HTML') {
+      content = content.replace(/<[^>]+>/g, '');
+    }
+
+    return sendTextMessage(baseUrl, token, message.address.chatId, content, contextToken);
+  }
+
+  // ── Config & Auth ───────────────────────────────────────────
+
+  validateConfig(): string | null {
+    const store = getBridgeContext().store;
+
+    const token = store.getSetting('bridge_wechat_token');
+    if (!token) return 'bridge_wechat_token not configured (run QR login setup first)';
+
+    return null;
+  }
+
+  isAuthorized(userId: string, _chatId: string): boolean {
+    const allowedUsers = getBridgeContext().store.getSetting('bridge_wechat_allowed_users') || '';
+    if (!allowedUsers) return true;
+
+    const allowed = allowedUsers
+      .split(',')
+      .map((s) => s.trim())
+      .filter(Boolean);
+
+    if (allowed.length === 0) return true;
+
+    return allowed.includes(userId);
+  }
+
+  // ── Long-poll loop ──────────────────────────────────────────
+
+  private runPollLoop(): void {
+    (async () => {
+      const store = getBridgeContext().store;
+      const token = store.getSetting('bridge_wechat_token') || '';
+      const baseUrl = store.getSetting('bridge_wechat_base_url') || DEFAULT_BASE_URL;
+
+      let consecutiveFailures = 0;
+
+      while (this._running) {
+        try {
+          const resp = await getUpdates(baseUrl, token, this.getUpdatesBuf);
+
+          // Handle API errors
+          const isError =
+            (resp.ret !== undefined && resp.ret !== 0) ||
+            (resp.errcode !== undefined && resp.errcode !== 0);
+
+          if (isError) {
+            consecutiveFailures++;
+            console.error(
+              `[wechat-adapter] getUpdates failed: ret=${resp.ret} errcode=${resp.errcode} errmsg=${resp.errmsg ?? ''}`,
+            );
+            if (consecutiveFailures >= MAX_CONSECUTIVE_FAILURES) {
+              console.error(
+                `[wechat-adapter] ${MAX_CONSECUTIVE_FAILURES} consecutive failures, backing off ${BACKOFF_DELAY_MS / 1000}s`,
+              );
+              consecutiveFailures = 0;
+              await this.delay(BACKOFF_DELAY_MS);
+            } else {
+              await this.delay(RETRY_DELAY_MS);
+            }
+            continue;
+          }
+
+          consecutiveFailures = 0;
+
+          // Save sync cursor
+          if (resp.get_updates_buf) {
+            this.getUpdatesBuf = resp.get_updates_buf;
+          }
+
+          // Process messages
+          for (const msg of resp.msgs ?? []) {
+            if (msg.message_type !== MSG_TYPE_USER) continue;
+
+            const text = extractTextFromMessage(msg);
+            if (!text) continue;
+
+            const senderId = msg.from_user_id ?? 'unknown';
+
+            // Dedup
+            const msgKey = `${senderId}:${msg.client_id || msg.create_time_ms || ''}`;
+            if (this.seenMessageIds.has(msgKey)) continue;
+            this.seenMessageIds.add(msgKey);
+
+            // Evict oldest when exceeding limit
+            if (this.seenMessageIds.size > 1000) {
+              const excess = this.seenMessageIds.size - 1000;
+              let removed = 0;
+              for (const key of this.seenMessageIds) {
+                if (removed >= excess) break;
+                this.seenMessageIds.delete(key);
+                removed++;
+              }
+            }
+
+            // Authorization check
+            if (!this.isAuthorized(senderId, senderId)) {
+              console.warn('[wechat-adapter] Unauthorized message from:', senderId);
+              continue;
+            }
+
+            // Cache context token for reply
+            if (msg.context_token) {
+              cacheContextToken(senderId, msg.context_token);
+            }
+
+            const messageId = msg.client_id || crypto.randomUUID();
+            const address = {
+              channelType: 'wechat' as const,
+              chatId: senderId,
+              userId: senderId,
+              displayName: senderId.split('@')[0] || senderId,
+            };
+
+            const inbound: InboundMessage = {
+              messageId,
+              address,
+              text,
+              timestamp: msg.create_time_ms || Date.now(),
+            };
+
+            this.enqueue(inbound);
+
+            // Audit log
+            try {
+              getBridgeContext().store.insertAuditLog({
+                channelType: 'wechat',
+                chatId: senderId,
+                direction: 'inbound',
+                messageId,
+                summary: text.slice(0, 200),
+              });
+            } catch { /* best effort */ }
+          }
+        } catch (err) {
+          if (this.pollAbort?.signal.aborted) break;
+
+          consecutiveFailures++;
+          console.error('[wechat-adapter] Poll error:', err instanceof Error ? err.message : err);
+
+          if (consecutiveFailures >= MAX_CONSECUTIVE_FAILURES) {
+            consecutiveFailures = 0;
+            await this.delay(BACKOFF_DELAY_MS);
+          } else {
+            await this.delay(RETRY_DELAY_MS);
+          }
+        }
+      }
+    })().catch((err) => {
+      if (!this.pollAbort?.signal.aborted) {
+        console.error('[wechat-adapter] Poll loop crashed:', err instanceof Error ? err.message : err);
+      }
+    });
+  }
+
+  private delay(ms: number): Promise<void> {
+    return new Promise((r) => setTimeout(r, ms));
+  }
+}
+
+// Self-register so bridge-manager can create WeChatAdapter via the registry.
+registerAdapterFactory('wechat', () => new WeChatAdapter());

--- a/src/lib/bridge/adapters/wechat-api.ts
+++ b/src/lib/bridge/adapters/wechat-api.ts
@@ -1,0 +1,251 @@
+/**
+ * WeChat ilink Bot HTTP protocol helpers.
+ *
+ * Pure protocol layer — no business logic, no adapter state.
+ * Covers QR login, long-poll message fetching, and message sending
+ * via the official WeChat ClawBot ilink API.
+ *
+ * Based on reverse-engineering from:
+ *   https://github.com/Johnixr/claude-code-wechat-channel
+ */
+
+import crypto from 'crypto';
+import type { SendResult } from '../types.js';
+
+// ── ilink API endpoints ────────────────────────────────────────
+
+const DEFAULT_BASE_URL = 'https://ilinkai.weixin.qq.com';
+const BOT_TYPE = '3';
+const CHANNEL_VERSION = '0.1.0';
+
+// ── Message type constants ─────────────────────────────────────
+
+export const MSG_TYPE_USER = 1;
+export const MSG_TYPE_BOT = 2;
+export const MSG_ITEM_TEXT = 1;
+export const MSG_ITEM_VOICE = 3;
+export const MSG_STATE_FINISH = 2;
+
+// ── Types ──────────────────────────────────────────────────────
+
+export interface WeixinMessage {
+  from_user_id?: string;
+  to_user_id?: string;
+  client_id?: string;
+  session_id?: string;
+  message_type?: number;
+  message_state?: number;
+  item_list?: MessageItem[];
+  context_token?: string;
+  create_time_ms?: number;
+}
+
+interface MessageItem {
+  type?: number;
+  text_item?: { text?: string };
+  voice_item?: { text?: string };
+  ref_msg?: { title?: string; message_item?: MessageItem };
+}
+
+export interface GetUpdatesResp {
+  ret?: number;
+  errcode?: number;
+  errmsg?: string;
+  msgs?: WeixinMessage[];
+  get_updates_buf?: string;
+  longpolling_timeout_ms?: number;
+}
+
+interface QRCodeResponse {
+  qrcode: string;
+  qrcode_img_content: string;
+}
+
+interface QRStatusResponse {
+  status: 'wait' | 'scaned' | 'confirmed' | 'expired';
+  bot_token?: string;
+  ilink_bot_id?: string;
+  baseurl?: string;
+  ilink_user_id?: string;
+}
+
+// ── HTTP helpers ───────────────────────────────────────────────
+
+function randomWechatUin(): string {
+  const uint32 = crypto.randomBytes(4).readUInt32BE(0);
+  return Buffer.from(String(uint32), 'utf-8').toString('base64');
+}
+
+function buildHeaders(token?: string, body?: string): Record<string, string> {
+  const headers: Record<string, string> = {
+    'Content-Type': 'application/json',
+    AuthorizationType: 'ilink_bot_token',
+    'X-WECHAT-UIN': randomWechatUin(),
+  };
+  if (body) {
+    headers['Content-Length'] = String(Buffer.byteLength(body, 'utf-8'));
+  }
+  if (token?.trim()) {
+    headers.Authorization = `Bearer ${token.trim()}`;
+  }
+  return headers;
+}
+
+async function apiFetch(params: {
+  baseUrl: string;
+  endpoint: string;
+  body: string;
+  token?: string;
+  timeoutMs: number;
+}): Promise<string> {
+  const base = params.baseUrl.endsWith('/') ? params.baseUrl : `${params.baseUrl}/`;
+  const url = new URL(params.endpoint, base).toString();
+  const headers = buildHeaders(params.token, params.body);
+  const res = await fetch(url, {
+    method: 'POST',
+    headers,
+    body: params.body,
+    signal: AbortSignal.timeout(params.timeoutMs),
+  });
+  const text = await res.text();
+  if (!res.ok) throw new Error(`HTTP ${res.status}: ${text}`);
+  return text;
+}
+
+// ── Context Token Cache ────────────────────────────────────────
+
+const contextTokenCache = new Map<string, string>();
+
+export function cacheContextToken(userId: string, token: string): void {
+  contextTokenCache.set(userId, token);
+}
+
+export function getCachedContextToken(userId: string): string | undefined {
+  return contextTokenCache.get(userId);
+}
+
+export function clearContextTokenCache(): void {
+  contextTokenCache.clear();
+}
+
+// ── Message text extraction ────────────────────────────────────
+
+export function extractTextFromMessage(msg: WeixinMessage): string {
+  if (!msg.item_list?.length) return '';
+  for (const item of msg.item_list) {
+    if (item.type === MSG_ITEM_TEXT && item.text_item?.text) {
+      const text = item.text_item.text;
+      const ref = item.ref_msg;
+      if (!ref) return text;
+      const parts: string[] = [];
+      if (ref.title) parts.push(ref.title);
+      if (!parts.length) return text;
+      return `[引用: ${parts.join(' | ')}]\n${text}`;
+    }
+    if (item.type === MSG_ITEM_VOICE && item.voice_item?.text) {
+      return item.voice_item.text;
+    }
+  }
+  return '';
+}
+
+// ── getUpdates (long-poll) ─────────────────────────────────────
+
+const LONG_POLL_TIMEOUT_MS = 35_000;
+
+export async function getUpdates(
+  baseUrl: string,
+  token: string,
+  getUpdatesBuf: string,
+): Promise<GetUpdatesResp> {
+  try {
+    const raw = await apiFetch({
+      baseUrl,
+      endpoint: 'ilink/bot/getupdates',
+      body: JSON.stringify({
+        get_updates_buf: getUpdatesBuf,
+        base_info: { channel_version: CHANNEL_VERSION },
+      }),
+      token,
+      timeoutMs: LONG_POLL_TIMEOUT_MS,
+    });
+    return JSON.parse(raw) as GetUpdatesResp;
+  } catch (err) {
+    if (err instanceof Error && err.name === 'AbortError') {
+      return { ret: 0, msgs: [], get_updates_buf: getUpdatesBuf };
+    }
+    throw err;
+  }
+}
+
+// ── sendMessage ────────────────────────────────────────────────
+
+function generateClientId(): string {
+  return `claude-bridge:${Date.now()}-${crypto.randomBytes(4).toString('hex')}`;
+}
+
+export async function sendTextMessage(
+  baseUrl: string,
+  token: string,
+  to: string,
+  text: string,
+  contextToken: string,
+): Promise<SendResult> {
+  const clientId = generateClientId();
+  try {
+    await apiFetch({
+      baseUrl,
+      endpoint: 'ilink/bot/sendmessage',
+      body: JSON.stringify({
+        msg: {
+          from_user_id: '',
+          to_user_id: to,
+          client_id: clientId,
+          message_type: MSG_TYPE_BOT,
+          message_state: MSG_STATE_FINISH,
+          item_list: [{ type: MSG_ITEM_TEXT, text_item: { text } }],
+          context_token: contextToken,
+        },
+        base_info: { channel_version: CHANNEL_VERSION },
+      }),
+      token,
+      timeoutMs: 15_000,
+    });
+    return { ok: true, messageId: clientId };
+  } catch (err) {
+    return { ok: false, error: err instanceof Error ? err.message : String(err) };
+  }
+}
+
+// ── QR Login ───────────────────────────────────────────────────
+
+export async function fetchQRCode(baseUrl: string = DEFAULT_BASE_URL): Promise<QRCodeResponse> {
+  const base = baseUrl.endsWith('/') ? baseUrl : `${baseUrl}/`;
+  const url = new URL(`ilink/bot/get_bot_qrcode?bot_type=${encodeURIComponent(BOT_TYPE)}`, base);
+  const res = await fetch(url.toString(), { signal: AbortSignal.timeout(10_000) });
+  if (!res.ok) throw new Error(`QR fetch failed: ${res.status}`);
+  return (await res.json()) as QRCodeResponse;
+}
+
+export async function pollQRStatus(
+  baseUrl: string,
+  qrcode: string,
+): Promise<QRStatusResponse> {
+  const base = baseUrl.endsWith('/') ? baseUrl : `${baseUrl}/`;
+  const url = new URL(`ilink/bot/get_qrcode_status?qrcode=${encodeURIComponent(qrcode)}`, base);
+  try {
+    const res = await fetch(url.toString(), {
+      headers: { 'iLink-App-ClientVersion': '1' },
+      signal: AbortSignal.timeout(35_000),
+    });
+    if (!res.ok) throw new Error(`QR status failed: ${res.status}`);
+    return (await res.json()) as QRStatusResponse;
+  } catch (err) {
+    if (err instanceof Error && err.name === 'AbortError') {
+      return { status: 'wait' };
+    }
+    throw err;
+  }
+}
+
+export { DEFAULT_BASE_URL };

--- a/src/lib/bridge/bridge-manager.ts
+++ b/src/lib/bridge/bridge-manager.ts
@@ -69,7 +69,7 @@ function getStreamConfig(channelType = 'telegram'): StreamConfig {
  * session lock would deadlock.
  */
 function isNumericPermissionShortcut(channelType: string, rawText: string, chatId: string): boolean {
-  if (channelType !== 'feishu' && channelType !== 'qq') return false;
+  if (channelType !== 'feishu' && channelType !== 'qq' && channelType !== 'wechat') return false;
   const normalized = rawText.normalize('NFKC').replace(/[\u200B-\u200D\uFEFF]/g, '').trim();
   if (!/^[123]$/.test(normalized)) return false;
   const { store } = getBridgeContext();
@@ -497,7 +497,7 @@ async function handleMessage(
   // Input normalization: mobile keyboards / IM clients may send fullwidth
   // digits (１２３), digits with zero-width joiners, or other Unicode
   // variants. NFKC normalization folds them all to ASCII 1/2/3.
-  if (adapter.channelType === 'feishu' || adapter.channelType === 'qq') {
+  if (adapter.channelType === 'feishu' || adapter.channelType === 'qq' || adapter.channelType === 'wechat') {
     // eslint-disable-next-line no-control-regex
     const normalized = rawText.normalize('NFKC').replace(/[\u200B-\u200D\uFEFF]/g, '').trim();
     if (/^[123]$/.test(normalized)) {

--- a/src/lib/bridge/permission-broker.ts
+++ b/src/lib/bridge/permission-broker.ts
@@ -59,8 +59,8 @@ export async function forwardPermissionRequest(
 
   let result: import('./types.js').SendResult;
 
-  if (adapter.channelType === 'qq') {
-    // QQ: plain text permission prompt with copyable /perm commands (no inline buttons)
+  if (adapter.channelType === 'qq' || adapter.channelType === 'wechat') {
+    // QQ/WeChat: plain text permission prompt with numeric shortcuts (no inline buttons)
     const qqText = [
       `Permission Required`,
       ``,

--- a/src/lib/bridge/types.ts
+++ b/src/lib/bridge/types.ts
@@ -185,4 +185,5 @@ export const PLATFORM_LIMITS: Record<string, number> = {
   slack: 40000,
   feishu: 30000,
   qq: 2000,
+  wechat: 4096,
 };


### PR DESCRIPTION
## 概述

添加微信个人账号支持，使用官方 ClawBot ilink 协议（与 `@tencent-weixin/openclaw-weixin` 使用相同 API）。

## 新增文件

| 文件 | 说明 |
|------|------|
| `adapters/wechat-api.ts` (251行) | ilink 协议层：getupdates 长轮询、sendmessage、QR 登录、context token 缓存 |
| `adapters/wechat-adapter.ts` (295行) | `BaseChannelAdapter` 实现：生命周期、消息队列、发送、鉴权 |

## 现有文件改动（4行）

| 文件 | 改动 |
|------|------|
| `adapters/index.ts` | +1行 import |
| `types.ts` | +1行 `wechat: 4096` |
| `bridge-manager.ts` | 2处 numeric permission shortcut 判断加 `wechat`（与 qq/feishu 同模式） |
| `permission-broker.ts` | 1处纯文本权限提示条件加 `wechat`（与 qq 同模式） |

## 功能

- 文本 + 语音转文字收消息
- 纯文本回复
- 数字权限快捷键（1/2/3）
- 消息去重、鉴权、审计日志
- API 失败指数退避

## 前置条件

- iOS 微信最新版（需启用 ClawBot 插件）
- Token 通过 QR 扫码获取

## 协议参考

基于 [Johnixr/claude-code-wechat-channel](https://github.com/Johnixr/claude-code-wechat-channel) 的协议逆向工程。

## 配套 PR

Skill wrapper 侧的配套改动：https://github.com/psylch/Claude-to-IM-skill/tree/feat/wechat-support