### PR TITLE
feat: add custom command hook and extensible help lines to bridge context

### DIFF
--- a/src/lib/bridge/bridge-manager.ts
+++ b/src/lib/bridge/bridge-manager.ts
@@ -810,9 +810,24 @@ async function handleCommand(
 
   let response = '';
 
+  // Check for custom command handlers first
+  const ctx = getBridgeContext();
+  if (ctx.onCommand) {
+    const customResponse = await ctx.onCommand(command, args, msg.address.chatId);
+    if (customResponse !== undefined) {
+      await deliver(adapter, {
+        address: msg.address,
+        text: customResponse,
+        parseMode: 'HTML',
+        replyToMessageId: msg.messageId,
+      });
+      return;
+    }
+  }
+
   switch (command) {
-    case '/start':
-      response = [
+    case '/start': {
+      const startLines = [
         '<b>CodePilot Bridge</b>',
         '',
         'Send any message to interact with Claude.',
@@ -827,8 +842,13 @@ async function handleCommand(
         '/stop - Stop current session',
         '/perm allow|allow_session|deny &lt;id&gt; - Respond to permission',
         '/help - Show this help',
-      ].join('\n');
+      ];
+      if (ctx.extraHelpLines) {
+        startLines.push(...ctx.extraHelpLines());
+      }
+      response = startLines.join('\n');
       break;
+    }
 
     case '/new': {
       // Abort any running task on the current session before creating a new one
@@ -961,8 +981,8 @@ async function handleCommand(
       break;
     }
 
-    case '/help':
-      response = [
+    case '/help': {
+      const helpLines = [
         '<b>CodePilot Bridge Commands</b>',
         '',
         '/new [path] - Start new session',
@@ -975,8 +995,13 @@ async function handleCommand(
         '/perm allow|allow_session|deny &lt;id&gt; - Respond to permission request',
         '1/2/3 - Quick permission reply (Feishu/QQ/WeChat, single pending)',
         '/help - Show this help',
-      ].join('\n');
+      ];
+      if (ctx.extraHelpLines) {
+        helpLines.push(...ctx.extraHelpLines());
+      }
+      response = helpLines.join('\n');
       break;
+    }
 
     default:
       response = `Unknown command: ${escapeHtml(command)}\nType /help for available commands.`;

--- a/src/lib/bridge/bridge-manager.ts
+++ b/src/lib/bridge/bridge-manager.ts
@@ -571,6 +571,22 @@ async function handleMessage(
     return;
   }
 
+  // Check for message intercept hook (e.g. numeric session selection)
+  const ctx = getBridgeContext();
+  if (ctx.onMessage) {
+    const intercepted = await ctx.onMessage(rawText, msg.address.chatId);
+    if (intercepted !== undefined) {
+      await deliver(adapter, {
+        address: msg.address,
+        text: intercepted,
+        parseMode: 'HTML',
+        replyToMessageId: msg.messageId,
+      });
+      ack();
+      return;
+    }
+  }
+
   // Sanitize general message text before routing to conversation engine
   const { text, truncated } = sanitizeInput(rawText);
   if (truncated) {
@@ -811,9 +827,9 @@ async function handleCommand(
   let response = '';
 
   // Check for custom command handlers first
-  const ctx = getBridgeContext();
-  if (ctx.onCommand) {
-    const customResponse = await ctx.onCommand(command, args, msg.address.chatId);
+  const cmdCtx = getBridgeContext();
+  if (cmdCtx.onCommand) {
+    const customResponse = await cmdCtx.onCommand(command, args, msg.address.chatId);
     if (customResponse !== undefined) {
       await deliver(adapter, {
         address: msg.address,
@@ -843,8 +859,8 @@ async function handleCommand(
         '/perm allow|allow_session|deny &lt;id&gt; - Respond to permission',
         '/help - Show this help',
       ];
-      if (ctx.extraHelpLines) {
-        startLines.push(...ctx.extraHelpLines());
+      if (cmdCtx.extraHelpLines) {
+        startLines.push(...cmdCtx.extraHelpLines());
       }
       response = startLines.join('\n');
       break;
@@ -996,8 +1012,8 @@ async function handleCommand(
         '1/2/3 - Quick permission reply (Feishu/QQ/WeChat, single pending)',
         '/help - Show this help',
       ];
-      if (ctx.extraHelpLines) {
-        helpLines.push(...ctx.extraHelpLines());
+      if (cmdCtx.extraHelpLines) {
+        helpLines.push(...cmdCtx.extraHelpLines());
       }
       response = helpLines.join('\n');
       break;

--- a/src/lib/bridge/context.ts
+++ b/src/lib/bridge/context.ts
@@ -30,6 +30,11 @@ export interface BridgeContext {
    */
   onCommand?(command: string, args: string, chatId: string): Promise<string | undefined>;
   /**
+   * Message intercept hook. Called for non-command messages before routing to LLM.
+   * Return a response string to send back (skipping LLM), or undefined to continue normal flow.
+   */
+  onMessage?(text: string, chatId: string): Promise<string | undefined>;
+  /**
    * Extra help lines appended to /help output. Each line is an HTML string.
    */
   extraHelpLines?(): string[];

--- a/src/lib/bridge/context.ts
+++ b/src/lib/bridge/context.ts
@@ -20,6 +20,19 @@ export interface BridgeContext {
   llm: LLMProvider;
   permissions: PermissionGateway;
   lifecycle: LifecycleHooks;
+  /**
+   * Replace the LLM provider at runtime (e.g. switching between Claude and Codex).
+   */
+  updateLLMProvider?(provider: LLMProvider): void;
+  /**
+   * Custom command handler. Called before the built-in /command switch.
+   * Return a response string if handled, or undefined to fall through.
+   */
+  onCommand?(command: string, args: string, chatId: string): Promise<string | undefined>;
+  /**
+   * Extra help lines appended to /help output. Each line is an HTML string.
+   */
+  extraHelpLines?(): string[];
 }
 
 const CONTEXT_KEY = '__bridge_context__';


### PR DESCRIPTION
## Motivation

Host applications (like claude-to-im-skill) need to add custom slash commands (e.g. `/runtime`) without forking or modifying the bridge library. Currently, `bridge-manager.ts` has a fixed switch statement for command handling.

## Changes

### `context.ts`
Add three optional extension points to `BridgeContext`:

- `updateLLMProvider(provider)` — swap the LLM provider at runtime (hot-switch between Claude and Codex)
- `onCommand(command, args, chatId)` — custom command handler, checked before the built-in switch. Returns response string or `undefined` to fall through.
- `extraHelpLines()` — returns extra HTML lines appended to `/start` and `/help` output

### `bridge-manager.ts`
- Before the built-in command switch, check `ctx.onCommand` first
- `/start` and `/help` commands call `ctx.extraHelpLines()` to append host-specific commands

## Backward compatible

All three new fields are optional (`?`). Existing hosts that don't provide them see zero behavior change.

## Testing

- `npm run typecheck` passes
- `npm run build` passes
- `npm test` — 63/63 pass