### PR TITLE
fix(feishu): replace broken CardKit SDK methods with direct v1 API calls

### DIFF
--- a/src/lib/bridge/adapters/feishu-adapter.ts
+++ b/src/lib/bridge/adapters/feishu-adapter.ts
@@ -146,6 +146,79 @@ export class FeishuAdapter extends BaseChannelAdapter {
       domain,
     });
 
+    // ── CardKit v1 API monkey-patch ───────────────────────────────────────────
+    // The SDK's built-in CardKit v2 methods use incorrect API paths and a broken
+    // token-fetch implementation. We replace them with direct fetch calls to the
+    // correct CardKit v1 endpoints using a custom getToken.
+    //
+    // Fixes: Card create returns no card_id, streamContent 404, streaming mode
+    // not properly disabled, final content update fails.
+    let _tenantAccessToken = '';
+    const _apiDomain = (this.restClient as any).domain || 'https://open.feishu.cn';
+    const getToken = async (): Promise<string> => {
+      if (_tenantAccessToken) return _tenantAccessToken;
+      try {
+        const res = await fetch(`${_apiDomain}/open-apis/auth/v3/tenant_access_token/internal`, {
+          method: 'POST',
+          headers: { 'Content-Type': 'application/json' },
+          body: JSON.stringify({ app_id: appId, app_secret: appSecret }),
+        });
+        const json = await res.json();
+        _tenantAccessToken = json?.tenant_access_token || '';
+      } catch (err) {
+        console.warn('[feishu-adapter] getToken failed:', err instanceof Error ? err.message : err);
+      }
+      return _tenantAccessToken;
+    };
+    (this.restClient as any).cardkit = (this.restClient as any).cardkit || {};
+    (this.restClient as any).cardkit.v2 = {
+      card: {
+        // POST /open-apis/cardkit/v1/cards — flat body {type, data}
+        create: async ({ data }: { data: any }) => {
+          const token = await getToken();
+          const res = await fetch(`${_apiDomain}/open-apis/cardkit/v1/cards`, {
+            method: 'POST',
+            headers: { 'Authorization': `Bearer ${token}`, 'Content-Type': 'application/json' },
+            body: JSON.stringify(data),  // flat {type, data}
+          });
+          return res.json();
+        },
+        // PUT /open-apis/cardkit/v1/cards/{id}/elements/{element_id}/content — flat body
+        streamContent: async ({ path, data }: { path: { card_id: string }; data: any }) => {
+          const token = await getToken();
+          return fetch(`${_apiDomain}/open-apis/cardkit/v1/cards/${path.card_id}/elements/streaming_content/content`, {
+            method: 'PUT',
+            headers: { 'Authorization': `Bearer ${token}`, 'Content-Type': 'application/json' },
+            body: JSON.stringify({ content: data.content, sequence: data.sequence }),
+          });
+        },
+        settings: {
+          streamingMode: {
+            // PATCH /open-apis/cardkit/v1/cards/{id}/settings — flat body
+            set: async ({ path, data }: { path: { card_id: string }; data: any }) => {
+              const token = await getToken();
+              return fetch(`${_apiDomain}/open-apis/cardkit/v1/cards/${path.card_id}/settings`, {
+                method: 'PATCH',
+                headers: { 'Authorization': `Bearer ${token}`, 'Content-Type': 'application/json' },
+                body: JSON.stringify({ settings: JSON.stringify({ streaming_mode: data.streaming_mode }), sequence: data.sequence }),
+              });
+            },
+          },
+        },
+        // PUT /open-apis/cardkit/v1/cards/{id} — flat body
+        update: async ({ path, data }: { path: { card_id: string }; data: any }) => {
+          const token = await getToken();
+          const res = await fetch(`${_apiDomain}/open-apis/cardkit/v1/cards/${path.card_id}`, {
+            method: 'PUT',
+            headers: { 'Authorization': `Bearer ${token}`, 'Content-Type': 'application/json' },
+            body: JSON.stringify({ card: { type: data.type, data: data.data }, sequence: data.sequence }),
+          });
+          return res.json();
+        },
+      },
+    };
+    // ── End CardKit patch ─────────────────────────────────────────────────────
+
     // Resolve bot identity for @mention detection
     await this.resolveBotIdentity(appId, appSecret, domain);
 


### PR DESCRIPTION
## Summary

The SDK's built-in `cardkit.v2.card.*` methods use incorrect API paths and a broken token-fetch implementation, causing streaming cards to fail silently.

## Changes

### `src/lib/bridge/adapters/feishu-adapter.ts`

After `restClient` creation, inject a monkey-patch that replaces the SDK's `cardkit.v2.card.*` methods with direct fetch calls to the correct **CardKit v1** endpoints:

| SDK Method | Replaced By | Issue |
|---|---|---|
| `card.create` | `POST /open-apis/cardkit/v1/cards` | Wrong API version |
| `streamContent` | `PUT /open-apis/cardkit/v1/cards/{id}/elements/streaming_content/content` | Path `cardElement/content` → correct v1 path |
| `settings.streamingMode.set` | `PATCH /open-apis/cardkit/v1/cards/{id}/settings` | Used `PUT` instead of `PATCH` |
| `card.update` | `PUT /open-apis/cardkit/v1/cards/{id}` | Body wrapped in extra `data` key |

Also adds a custom `getToken()` that uses direct `fetch` to `/open-apis/auth/v3/tenant_access_token/internal` instead of the broken SDK method (`auth.v3.tenantAccessToken.internal.post` does not exist in `@larksuiteoapi/node-sdk`).

## Notes

- The patch is inserted **after** `restClient` creation and **before** `resolveBotIdentity()`, so it runs before any CardKit operations
- All existing call sites (`createStreamingCard`, `updateCardContent`, `finalizeCard`) remain unchanged — they call `this.restClient.cardkit.v2.card.*` as before and transparently use the patched methods
- The patch must be applied in the `start()` method to ensure it runs on every bridge restart
- Token is cached in `_tenantAccessToken` and reused until the bridge restarts

## Symptoms Before Fix

- `Card create returned no card_id` in logs
- Streaming cards not appearing in Feishu
- Card finalization returning 404