### PR TITLE
fix: preserve sdkSessionId on error to prevent conversation amnesia

### DIFF
--- a/src/__tests__/unit/bridge-qq.test.ts
+++ b/src/__tests__/unit/bridge-qq.test.ts
@@ -919,16 +919,16 @@ describe('bridge-manager - computeSdkSessionUpdate', () => {
     assert.equal(result, 'new-sdk-123');
   });
 
-  it('clears sdkSessionId on error even when sdkSessionId is present', async () => {
+  it('preserves sdkSessionId on error when sdkSessionId is present', async () => {
     const { computeSdkSessionUpdate } = await import('../../lib/bridge/bridge-manager');
     const result = computeSdkSessionUpdate('new-sdk-123', true);
-    assert.equal(result, '', 'Error with SDK ID: should clear');
+    assert.equal(result, 'new-sdk-123', 'Error with SDK ID: should preserve for resume');
   });
 
-  it('clears sdkSessionId on error even without sdkSessionId', async () => {
+  it('returns null on error without sdkSessionId (preserves existing)', async () => {
     const { computeSdkSessionUpdate } = await import('../../lib/bridge/bridge-manager');
     const result = computeSdkSessionUpdate(null, true);
-    assert.equal(result, '', 'Error without SDK ID: should clear');
+    assert.equal(result, null, 'Error without SDK ID: no update, preserve existing');
   });
 
   it('returns null (no update) when no error and no sdkSessionId', async () => {

--- a/src/lib/bridge/bridge-manager.ts
+++ b/src/lib/bridge/bridge-manager.ts
@@ -999,20 +999,26 @@ async function handleCommand(
  * Returns the new value to write, or null if no update is needed.
  *
  * Rules:
- * - If result has sdkSessionId AND no error → save the new ID
- * - If result has error (regardless of sdkSessionId) → clear to empty string
- * - Otherwise → no update needed
+ * - If result has sdkSessionId (regardless of error) → save/keep the ID
+ *   so the next message can resume the same conversation context.
+ * - If no sdkSessionId was captured → no update (preserve existing).
+ *
+ * Rationale: Clearing the sdkSessionId on transient errors (timeouts,
+ * rate limits, tool crashes) causes the next message to start a fresh
+ * session, losing all prior conversation context. Since the SDK session
+ * itself is still valid on the server side, preserving the ID allows
+ * seamless resume and avoids the "amnesia" problem.
  */
 export function computeSdkSessionUpdate(
   sdkSessionId: string | null | undefined,
   hasError: boolean,
 ): string | null {
-  if (sdkSessionId && !hasError) {
+  // Always persist a captured session ID — even after errors the session
+  // is still resumable on the server side.
+  if (sdkSessionId) {
     return sdkSessionId;
   }
-  if (hasError) {
-    return '';
-  }
+  // No session ID captured: leave the existing binding value untouched.
   return null;
 }
 


### PR DESCRIPTION
## Problem

When a transient error occurs during a conversation (timeout, rate limit, tool crash, context overflow), `computeSdkSessionUpdate()` clears the `sdkSessionId` to an empty string. This causes the next message to start a completely fresh Claude session with **no conversation history**, leading to the "amnesia" problem where the bot suddenly forgets everything discussed in the conversation.

This is a significant UX issue in group chats — users experience the bot randomly losing context mid-conversation, needing to re-explain what was already discussed.

## Root Cause

In `bridge-manager.ts`, `computeSdkSessionUpdate()` has the rule:
```
If result has error (regardless of sdkSessionId) → clear to empty string
```

This is overly aggressive. The SDK session on the server side is still valid and resumable even after a transient error. Clearing the session ID throws away the ability to resume.

## Fix

Changed `computeSdkSessionUpdate()` to:
- **Always preserve** a captured `sdkSessionId`, even when `hasError` is true
- When no `sdkSessionId` was captured, return `null` (no update) to preserve whatever ID was previously stored

This means transient errors no longer cause context loss. Users can still manually reset with `/new` if they want a fresh session.

## Test Changes

Updated the two test cases in `bridge-qq.test.ts` to match the new behavior:
- "clears sdkSessionId on error even when present" → "preserves sdkSessionId on error when present"  
- "clears sdkSessionId on error without sdkSessionId" → "returns null on error without sdkSessionId (preserves existing)"