### PR TITLE
feat: add incremental telegram bridge delivery

### DIFF
--- a/src/lib/bridge/adapters/telegram-adapter.ts
+++ b/src/lib/bridge/adapters/telegram-adapter.ts
@@ -206,6 +206,31 @@ export class TelegramAdapter extends BaseChannelAdapter {
     return callTelegramApi(token, 'sendMessage', params);
   }
 
+  async editMessage(
+    chatId: string,
+    messageId: string,
+    text: string,
+    parseMode?: OutboundMessage['parseMode'],
+  ): Promise<SendResult> {
+    const token = this.botToken;
+    if (!token) return { ok: false, error: 'No bot token configured' };
+
+    const params: Record<string, unknown> = {
+      chat_id: chatId,
+      message_id: Number(messageId),
+      text,
+      disable_web_page_preview: true,
+    };
+
+    if (parseMode === 'HTML') {
+      params.parse_mode = 'HTML';
+    } else if (parseMode === 'Markdown') {
+      params.parse_mode = 'Markdown';
+    }
+
+    return callTelegramApi(token, 'editMessageText', params);
+  }
+
   async answerCallback(callbackQueryId: string, text?: string): Promise<void> {
     const token = this.botToken;
     if (!token) return;

--- a/src/lib/bridge/bridge-manager.ts
+++ b/src/lib/bridge/bridge-manager.ts
@@ -8,6 +8,7 @@
  */
 
 import type { BridgeStatus, InboundMessage, OutboundMessage, StreamingPreviewState, ToolCallInfo } from './types.js';
+import type { MessageContentBlock } from './host.js';
 import { createAdapter, getRegisteredTypes } from './channel-adapter.js';
 import type { BaseChannelAdapter } from './channel-adapter.js';
 // Side-effect import: triggers self-registration of all adapter factories
@@ -150,6 +151,126 @@ async function deliverResponse(
   return deliver(adapter, {
     address,
     text: responseText,
+    parseMode: 'plain',
+    replyToMessageId,
+  }, { sessionId });
+}
+
+function supportsIncrementalParts(
+  adapter: BaseChannelAdapter,
+  chatId: string,
+  hasStreamingCards: boolean,
+): boolean {
+  if (hasStreamingCards) return false;
+  if (adapter.channelType === 'telegram') return true;
+  const caps = adapter.getPreviewCapabilities?.(chatId) ?? null;
+  if (caps?.supported) return false;
+  return adapter.channelType === 'qq' || adapter.channelType === 'weixin';
+}
+
+function renderContentBlock(block: MessageContentBlock): { text: string; markdown: boolean } | null {
+  if (block.type === 'text') {
+    const text = block.text.trim();
+    return text ? { text, markdown: true } : null;
+  }
+
+  if (block.type === 'tool_use') {
+    return {
+      text: [
+        `[tool_use] ${block.name}`,
+        '',
+        '```json',
+        JSON.stringify(block.input, null, 2),
+        '```',
+      ].join('\n'),
+      markdown: true,
+    };
+  }
+
+  if (block.type === 'tool_result') {
+    const body = typeof block.content === 'string'
+      ? block.content
+      : JSON.stringify(block.content, null, 2);
+    return {
+      text: [
+        `[tool_result${block.is_error ? ':error' : ''}] ${block.tool_use_id}`,
+        '',
+        body || '(empty)',
+      ].join('\n'),
+      markdown: true,
+    };
+  }
+
+  if (block.type === 'code') {
+    return {
+      text: `\`\`\`${block.language}\n${block.code}\n\`\`\``,
+      markdown: true,
+    };
+  }
+
+  return null;
+}
+
+function renderToolStatusMessage(
+  toolName: string,
+  status: 'running' | 'success' | 'error',
+  toolInput?: unknown,
+): { text: string; markdown: boolean } {
+  const statusText = status === 'running'
+    ? '⏳ 运行中'
+    : status === 'success'
+      ? '✅ 成功'
+      : '❌ 失败';
+
+  const details = (() => {
+    if (!toolInput) return null;
+    if (
+      toolName === 'Bash' &&
+      typeof toolInput === 'object' &&
+      toolInput !== null &&
+      'command' in toolInput &&
+      typeof (toolInput as { command?: unknown }).command === 'string'
+    ) {
+      return [
+        '```sh',
+        (toolInput as { command: string }).command,
+        '```',
+      ].join('\n');
+    }
+    return [
+      '```json',
+      JSON.stringify(toolInput, null, 2),
+      '```',
+    ].join('\n');
+  })();
+
+  return {
+    text: [
+      `🛠️ [tool] ${toolName}`,
+      details ? `\n${details}\n` : '',
+      `状态: ${statusText}`,
+    ].filter(Boolean).join('\n'),
+    markdown: true,
+  };
+}
+
+async function deliverContentBlock(
+  adapter: BaseChannelAdapter,
+  address: ChannelAddress,
+  block: MessageContentBlock,
+  sessionId: string,
+  replyToMessageId?: string,
+): Promise<SendResult> {
+  const rendered = renderContentBlock(block);
+  if (!rendered) return { ok: true };
+
+  if (rendered.markdown) {
+    return deliverResponse(adapter, address, rendered.text, sessionId, replyToMessageId);
+  }
+
+  return deliver(adapter, {
+    address,
+    text: rendered.text,
     parseMode: 'plain',
     replyToMessageId,
   }, { sessionId });
@@ -597,9 +718,15 @@ async function handleMessage(
   const state = getState();
   state.activeTasks.set(binding.codepilotSessionId, taskAbort);
 
+  // ── Streaming card / incremental mode detection ──────────────
+  const hasStreamingCards = typeof adapter.onStreamText === 'function';
+  const incrementalParts = supportsIncrementalParts(adapter, msg.address.chatId, hasStreamingCards);
+
   // ── Streaming preview setup ──────────────────────────────────
   let previewState: StreamingPreviewState | null = null;
-  const caps = adapter.getPreviewCapabilities?.(msg.address.chatId) ?? null;
+  const caps = incrementalParts
+    ? null
+    : (adapter.getPreviewCapabilities?.(msg.address.chatId) ?? null);
   if (caps?.supported) {
     previewState = {
       draftId: generateDraftId(),
@@ -663,8 +790,8 @@ async function handleMessage(
   // onStreamText, onToolEvent, and onStreamEnd callbacks.
   // These run in parallel with the existing preview system — Feishu
   // uses cards instead of message edit for streaming.
-  const hasStreamingCards = typeof adapter.onStreamText === 'function';
   const toolCallTracker = new Map<string, ToolCallInfo>();
+  const toolStatusMessages = new Map<string, { messageId: string; name: string; input?: unknown }>();
 
   const onStreamCardText = hasStreamingCards ? (fullText: string) => {
     try { adapter.onStreamText!(msg.address.chatId, fullText); } catch { /* non-critical */ }
@@ -706,7 +833,99 @@ async function handleMessage(
         perm.suggestions,
         msg.messageId,
       );
-    }, taskAbort.signal, hasAttachments ? msg.attachments : undefined, onPartialText, onToolEvent);
+    }, taskAbort.signal, hasAttachments ? msg.attachments : undefined, onPartialText, onToolEvent, async (block) => {
+      if (!incrementalParts) return;
+
+      if (block.type === 'tool_use') {
+        const rendered = renderToolStatusMessage(block.name, 'running', block.input);
+        const sendResult = rendered.markdown
+          ? await deliverResponse(
+            adapter,
+            msg.address,
+            rendered.text,
+            binding.codepilotSessionId,
+            msg.messageId,
+          )
+          : await deliver(adapter, {
+            address: msg.address,
+            text: rendered.text,
+            parseMode: 'plain',
+            replyToMessageId: msg.messageId,
+          }, { sessionId: binding.codepilotSessionId });
+
+        if (sendResult.ok && sendResult.messageId) {
+          toolStatusMessages.set(block.id, {
+            messageId: sendResult.messageId,
+            name: block.name,
+            input: block.input,
+          });
+        }
+        return;
+      }
+
+      if (block.type === 'tool_result') {
+        const existing = toolStatusMessages.get(block.tool_use_id);
+        if (existing) {
+          const rendered = renderToolStatusMessage(
+            existing.name,
+            block.is_error ? 'error' : 'success',
+            existing.input,
+          );
+
+          if (adapter.editMessage) {
+            const editResult = await adapter.editMessage(
+              msg.address.chatId,
+              existing.messageId,
+              rendered.text,
+              rendered.markdown ? 'Markdown' : 'plain',
+            );
+            if (!editResult.ok) {
+              console.warn(
+                '[bridge-manager] Tool status update failed:',
+                editResult.error || 'unknown error',
+              );
+            }
+            return;
+          }
+
+          const fallbackResult = rendered.markdown
+            ? await deliverResponse(
+              adapter,
+              msg.address,
+              rendered.text,
+              binding.codepilotSessionId,
+              msg.messageId,
+            )
+            : await deliver(adapter, {
+              address: msg.address,
+              text: rendered.text,
+              parseMode: 'plain',
+              replyToMessageId: msg.messageId,
+            }, { sessionId: binding.codepilotSessionId });
+          if (!fallbackResult.ok) {
+            console.warn(
+              '[bridge-manager] Tool status fallback delivery failed:',
+              fallbackResult.error || 'unknown error',
+            );
+          }
+          return;
+        }
+      }
+
+      const sendResult = await deliverContentBlock(
+        adapter,
+        msg.address,
+        block,
+        binding.codepilotSessionId,
+        msg.messageId,
+      );
+      if (!sendResult.ok) {
+        console.warn(
+          '[bridge-manager] Incremental part delivery failed:',
+          sendResult.error || 'unknown error',
+        );
+      }
+    });
 
     // Finalize streaming card if adapter supports it.
     // onStreamEnd awaits any in-flight card creation and returns true if a card
@@ -725,7 +944,9 @@ async function handleMessage(
     // Skip if streaming card was finalized (content already in card).
     if (result.responseText) {
       if (!cardFinalized) {
-        await deliverResponse(adapter, msg.address, result.responseText, binding.codepilotSessionId, msg.messageId);
+        if (!incrementalParts) {
+          await deliverResponse(adapter, msg.address, result.responseText, binding.codepilotSessionId, msg.messageId);
+        }
       }
     } else if (result.hasError) {
       const errorResponse: OutboundMessage = {

--- a/src/lib/bridge/bridge-manager.ts
+++ b/src/lib/bridge/bridge-manager.ts
@@ -724,9 +724,10 @@ async function handleMessage(
 
   // ── Streaming preview setup ──────────────────────────────────
   let previewState: StreamingPreviewState | null = null;
-  const caps = incrementalParts
-    ? null
-    : (adapter.getPreviewCapabilities?.(msg.address.chatId) ?? null);
+  const allowPreviewWithIncremental = adapter.channelType === 'telegram';
+  const caps = (!incrementalParts || allowPreviewWithIncremental)
+    ? (adapter.getPreviewCapabilities?.(msg.address.chatId) ?? null)
+    : null;
   if (caps?.supported) {
     previewState = {
       draftId: generateDraftId(),

--- a/src/lib/bridge/channel-adapter.ts
+++ b/src/lib/bridge/channel-adapter.ts
@@ -46,6 +46,19 @@ export abstract class BaseChannelAdapter {
   abstract send(message: OutboundMessage): Promise<SendResult>;
 
   /**
+   * Edit a previously sent outbound message.
+   * Default is unsupported; adapters can override when the platform allows it.
+   */
+  async editMessage?(
+    _chatId: string,
+    _messageId: string,
+    _text: string,
+    _parseMode?: OutboundMessage['parseMode'],
+  ): Promise<SendResult> {
+    return { ok: false, error: 'editMessage not supported' };
+  }
+
+  /**
    * Answer a callback query (e.g. Telegram inline button press).
    * Not all platforms support this — default implementation is a no-op.
    */

--- a/src/lib/bridge/conversation-engine.ts
+++ b/src/lib/bridge/conversation-engine.ts
@@ -45,8 +45,16 @@ export type OnPartialText = (fullText: string) => void;
  */
 export type OnToolEvent = (toolId: string, toolName: string, status: 'running' | 'complete' | 'error') => void;
 
+/**
+ * Callback invoked when a content block is finalized during stream consumption.
+ * Used by bridge-manager to forward text/tool blocks incrementally to channels
+ * that do not support native streaming previews.
+ */
+export type OnContentBlock = (block: MessageContentBlock) => Promise<void>;
+
 export interface ConversationResult {
   responseText: string;
+  responseParts: MessageContentBlock[];
   tokenUsage: TokenUsage | null;
   hasError: boolean;
   errorMessage: string;
@@ -68,6 +76,7 @@ export async function processMessage(
   files?: FileAttachment[],
   onPartialText?: OnPartialText,
   onToolEvent?: OnToolEvent,
+  onContentBlock?: OnContentBlock,
 ): Promise<ConversationResult> {
   const { store, llm } = getBridgeContext();
   const sessionId = binding.codepilotSessionId;
@@ -78,6 +87,7 @@ export async function processMessage(
   if (!lockAcquired) {
     return {
       responseText: '',
+      responseParts: [],
       tokenUsage: null,
       hasError: true,
       errorMessage: 'Session is busy processing another request',
@@ -184,7 +194,7 @@ export async function processMessage(
     // Consume the stream server-side (replicate collectStreamResponse pattern).
     // Permission requests are forwarded immediately via the callback during streaming
     // because the stream blocks until permission is resolved — we can't wait until after.
-    return await consumeStream(stream, sessionId, onPermissionRequest, onPartialText, onToolEvent);
+    return await consumeStream(stream, sessionId, onPermissionRequest, onPartialText, onToolEvent, onContentBlock);
   } finally {
     clearInterval(renewalInterval);
     store.releaseSessionLock(sessionId, lockId);
@@ -202,6 +212,7 @@ async function consumeStream(
   onPermissionRequest?: OnPermissionRequest,
   onPartialText?: OnPartialText,
   onToolEvent?: OnToolEvent,
+  onContentBlock?: OnContentBlock,
 ): Promise<ConversationResult> {
   const { store } = getBridgeContext();
   const reader = stream.getReader();
@@ -217,6 +228,16 @@ async function consumeStream(
   let capturedSdkSessionId: string | null = null;
 
   try {
+    const flushCurrentText = async (): Promise<void> => {
+      if (!currentText.trim()) return;
+      const textBlock: MessageContentBlock = { type: 'text', text: currentText };
+      contentBlocks.push(textBlock);
+      currentText = '';
+      if (onContentBlock) {
+        await onContentBlock(textBlock);
+      }
+    };
+
     while (true) {
       const { done, value } = await reader.read();
       if (done) break;
@@ -242,18 +263,19 @@ async function consumeStream(
             break;
 
           case 'tool_use': {
-            if (currentText.trim()) {
-              contentBlocks.push({ type: 'text', text: currentText });
-              currentText = '';
-            }
+            await flushCurrentText();
             try {
               const toolData = JSON.parse(event.data);
-              contentBlocks.push({
+              const toolBlock: MessageContentBlock = {
                 type: 'tool_use',
                 id: toolData.id,
                 name: toolData.name,
                 input: toolData.input,
-              });
+              };
+              contentBlocks.push(toolBlock);
+              if (onContentBlock) {
+                await onContentBlock(toolBlock);
+              }
               if (onToolEvent) {
                 try { onToolEvent(toolData.id, toolData.name, 'running'); } catch { /* non-critical */ }
               }
@@ -264,7 +286,7 @@ async function consumeStream(
           case 'tool_result': {
             try {
               const resultData = JSON.parse(event.data);
-              const newBlock = {
+              const newBlock: MessageContentBlock = {
                 type: 'tool_result' as const,
                 tool_use_id: resultData.tool_use_id,
                 content: resultData.content,
@@ -278,6 +300,9 @@ async function consumeStream(
               } else {
                 seenToolResultIds.add(resultData.tool_use_id);
                 contentBlocks.push(newBlock);
+              }
+              if (onContentBlock) {
+                await onContentBlock(newBlock);
               }
               if (onToolEvent) {
                 try {
@@ -361,9 +386,7 @@ async function consumeStream(
     }
 
     // Flush remaining text
-    if (currentText.trim()) {
-      contentBlocks.push({ type: 'text', text: currentText });
-    }
+    await flushCurrentText();
 
     // Save assistant message
     if (contentBlocks.length > 0) {
@@ -392,6 +415,7 @@ async function consumeStream(
 
     return {
       responseText,
+      responseParts: contentBlocks,
       tokenUsage,
       hasError,
       errorMessage,
@@ -424,6 +448,7 @@ async function consumeStream(
 
     return {
       responseText: '',
+      responseParts: contentBlocks,
       tokenUsage,
       hasError: true,
       errorMessage: isAbort ? 'Task stopped by user' : (e instanceof Error ? e.message : 'Stream consumption error'),


### PR DESCRIPTION
## Summary
- add incremental content-block delivery for bridge responses
- enable Telegram incremental delivery and disable preview when incremental mode is active
- add Telegram message editing support for tool status updates
- show tool input in Telegram and update only the status line on completion

## Testing
- npm run typecheck
- npm test