### PR TITLE
Handle busy sessions and degrade Feishu CardKit fallback

### DIFF
--- a/src/__tests__/unit/bridge-manager.test.ts
+++ b/src/__tests__/unit/bridge-manager.test.ts
@@ -131,6 +131,98 @@ describe('bridge-manager lifecycle', () => {
     assert.equal(status.running, false);
     assert.equal(status.adapters.length, 0);
   });
+
+  it('returns an explicit busy reply instead of silently queueing same-session follow-ups', async () => {
+    const store = createMinimalStore({ remote_bridge_enabled: 'false' });
+    initBridgeContext({
+      store,
+      llm: { streamChat: () => new ReadableStream() },
+      permissions: { resolvePendingPermission: () => false },
+      lifecycle: {},
+    });
+
+    const sent: string[] = [];
+    const adapter = {
+      channelType: 'weixin',
+      send: async (message: { text: string }) => {
+        sent.push(message.text);
+        return { ok: true, messageId: 'busy-msg' };
+      },
+      acknowledgeUpdate: () => {},
+    } as any;
+
+    const { _testOnly, getStatus } = await import('../../lib/bridge/bridge-manager');
+    getStatus();
+    const state = (globalThis as Record<string, any>)['__bridge_manager__'];
+    state.activeTasks.set('session-1', {
+      abortController: new AbortController(),
+      startedAt: Date.now() - 30_000,
+      lastActivityAt: Date.now() - 5_000,
+    });
+
+    const handled = await _testOnly.maybeHandleBusySession(adapter, {
+      messageId: 'm-1',
+      address: { channelType: 'weixin', chatId: 'chat-1', userId: 'u-1' },
+      text: 'still there?',
+      timestamp: Date.now(),
+    }, 'session-1');
+
+    assert.equal(handled, true);
+    assert.equal(sent.length, 1);
+    assert.match(sent[0], /Current task is still running/);
+    assert.match(sent[0], /\/stop/);
+  });
+
+  it('aborts stale active tasks so the next message can proceed', async () => {
+    const oldStale = process.env.CTI_ACTIVE_TASK_STALE_MS;
+    process.env.CTI_ACTIVE_TASK_STALE_MS = '1000';
+
+    try {
+      const store = createMinimalStore({ remote_bridge_enabled: 'false' });
+      initBridgeContext({
+        store,
+        llm: { streamChat: () => new ReadableStream() },
+        permissions: { resolvePendingPermission: () => false },
+        lifecycle: {},
+      });
+
+      const sent: string[] = [];
+      const adapter = {
+        channelType: 'weixin',
+        send: async (message: { text: string }) => {
+          sent.push(message.text);
+          return { ok: true, messageId: 'stale-msg' };
+        },
+        acknowledgeUpdate: () => {},
+      } as any;
+
+      const { _testOnly, getStatus } = await import('../../lib/bridge/bridge-manager');
+      getStatus();
+      const state = (globalThis as Record<string, any>)['__bridge_manager__'];
+      const abortController = new AbortController();
+      state.activeTasks.set('session-2', {
+        abortController,
+        startedAt: Date.now() - 120_000,
+        lastActivityAt: Date.now() - 90_000,
+      });
+
+      const handled = await _testOnly.maybeHandleBusySession(adapter, {
+        messageId: 'm-2',
+        address: { channelType: 'weixin', chatId: 'chat-2', userId: 'u-2' },
+        text: 'retry this',
+        timestamp: Date.now(),
+      }, 'session-2');
+
+      assert.equal(handled, false);
+      assert.equal(abortController.signal.aborted, true);
+      assert.equal(state.activeTasks.has('session-2'), false);
+      assert.equal(sent.length, 1);
+      assert.match(sent[0], /looked stuck/);
+    } finally {
+      if (oldStale === undefined) delete process.env.CTI_ACTIVE_TASK_STALE_MS;
+      else process.env.CTI_ACTIVE_TASK_STALE_MS = oldStale;
+    }
+  });
 });
 
 function createMinimalStore(settings: Record<string, string> = {}): BridgeStore {

--- a/src/lib/bridge/adapters/feishu-adapter.ts
+++ b/src/lib/bridge/adapters/feishu-adapter.ts
@@ -120,6 +120,9 @@ export class FeishuAdapter extends BaseChannelAdapter {
   private activeCards = new Map<string, FeishuCardState>();
   /** In-flight card creation promises per chatId — prevents duplicate creation. */
   private cardCreatePromises = new Map<string, Promise<boolean>>();
+  /** Disable streaming card attempts when CardKit APIs are unavailable. */
+  private cardKitUnavailable = false;
+  private cardKitWarned = false;
 
   // ── Lifecycle ───────────────────────────────────────────────
 
@@ -358,7 +361,18 @@ export class FeishuAdapter extends BaseChannelAdapter {
    * Returns true if card was created successfully.
    */
   private createStreamingCard(chatId: string, replyToMessageId?: string): Promise<boolean> {
-    if (!this.restClient || this.activeCards.has(chatId)) return Promise.resolve(false);
+    if (!this.restClient || this.activeCards.has(chatId) || this.cardKitUnavailable) {
+      return Promise.resolve(false);
+    }
+
+    if (!(this.restClient as any).cardkit?.v2?.card) {
+      this.cardKitUnavailable = true;
+      if (!this.cardKitWarned) {
+        this.cardKitWarned = true;
+        console.warn('[feishu-adapter] CardKit v2 API unavailable; falling back to non-streaming replies');
+      }
+      return Promise.resolve(false);
+    }
 
     // In-flight guard: if creation is already in progress, return the existing promise
     const existing = this.cardCreatePromises.get(chatId);
@@ -372,6 +386,11 @@ export class FeishuAdapter extends BaseChannelAdapter {
 
   private async _doCreateStreamingCard(chatId: string, replyToMessageId?: string): Promise<boolean> {
     if (!this.restClient) return false;
+    const cardApi = (this.restClient as any).cardkit?.v2?.card;
+    if (!cardApi) {
+      this.cardKitUnavailable = true;
+      return false;
+    }
 
     try {
       // Step 1: Create card via CardKit v2
@@ -393,7 +412,7 @@ export class FeishuAdapter extends BaseChannelAdapter {
         },
       };
 
-      const createResp = await (this.restClient as any).cardkit.v2.card.create({
+      const createResp = await cardApi.create({
         data: { type: 'card_json', data: JSON.stringify(cardBody) },
       });
       const cardId = createResp?.data?.card_id;
@@ -487,6 +506,11 @@ export class FeishuAdapter extends BaseChannelAdapter {
   private flushCardUpdate(chatId: string): void {
     const state = this.activeCards.get(chatId);
     if (!state || !this.restClient) return;
+    const cardApi = (this.restClient as any).cardkit?.v2?.card;
+    if (!cardApi) {
+      this.cardKitUnavailable = true;
+      return;
+    }
 
     const content = buildStreamingContent(state.pendingText || '', state.toolCalls);
 
@@ -495,7 +519,7 @@ export class FeishuAdapter extends BaseChannelAdapter {
     const cardId = state.cardId;
 
     // Fire-and-forget — streaming updates are non-critical
-    (this.restClient as any).cardkit.v2.card.streamContent({
+    cardApi.streamContent({
       path: { card_id: cardId },
       data: { content, sequence: seq },
     }).then(() => {
@@ -532,6 +556,12 @@ export class FeishuAdapter extends BaseChannelAdapter {
 
     const state = this.activeCards.get(chatId);
     if (!state || !this.restClient) return false;
+    const cardApi = (this.restClient as any).cardkit?.v2?.card;
+    const streamingModeApi = cardApi?.settings?.streamingMode;
+    if (!cardApi || !streamingModeApi) {
+      this.cardKitUnavailable = true;
+      return false;
+    }
 
     // Clear any pending throttle timer
     if (state.throttleTimer) {
@@ -542,7 +572,7 @@ export class FeishuAdapter extends BaseChannelAdapter {
     try {
       // Step 1: Close streaming mode
       state.sequence++;
-      await (this.restClient as any).cardkit.v2.card.settings.streamingMode.set({
+      await streamingModeApi.set({
         path: { card_id: state.cardId },
         data: { streaming_mode: false, sequence: state.sequence },
       });
@@ -562,7 +592,7 @@ export class FeishuAdapter extends BaseChannelAdapter {
       const finalCardJson = buildFinalCardJson(responseText, state.toolCalls, footer);
 
       state.sequence++;
-      await (this.restClient as any).cardkit.v2.card.update({
+      await cardApi.update({
         path: { card_id: state.cardId },
         data: { type: 'card_json', data: finalCardJson, sequence: state.sequence },
       });

--- a/src/lib/bridge/bridge-manager.ts
+++ b/src/lib/bridge/bridge-manager.ts
@@ -160,13 +160,19 @@ interface AdapterMeta {
   lastError: string | null;
 }
 
+interface ActiveTaskState {
+  abortController: AbortController;
+  startedAt: number;
+  lastActivityAt: number;
+}
+
 interface BridgeManagerState {
   adapters: Map<string, BaseChannelAdapter>;
   adapterMeta: Map<string, AdapterMeta>;
   running: boolean;
   startedAt: string | null;
   loopAborts: Map<string, AbortController>;
-  activeTasks: Map<string, AbortController>;
+  activeTasks: Map<string, ActiveTaskState>;
   /** Per-session processing chains for concurrency control */
   sessionLocks: Map<string, Promise<void>>;
   autoStartChecked: boolean;
@@ -210,6 +216,68 @@ function processWithSessionLock(sessionId: string, fn: () => Promise<void>): Pro
     }
   }).catch(() => {});
   return current;
+}
+
+function getActiveTaskStaleMs(): number {
+  const raw = process.env.CTI_ACTIVE_TASK_STALE_MS || process.env.CTI_TASK_STALE_MS;
+  const parsed = raw ? Number(raw) : NaN;
+  return Number.isFinite(parsed) && parsed > 0 ? parsed : 15 * 60_000;
+}
+
+function formatDuration(ms: number): string {
+  const totalSeconds = Math.max(0, Math.floor(ms / 1000));
+  if (totalSeconds < 60) return `${totalSeconds}s`;
+  const minutes = Math.floor(totalSeconds / 60);
+  const seconds = totalSeconds % 60;
+  if (minutes < 60) return seconds > 0 ? `${minutes}m ${seconds}s` : `${minutes}m`;
+  const hours = Math.floor(minutes / 60);
+  const remMinutes = minutes % 60;
+  return remMinutes > 0 ? `${hours}h ${remMinutes}m` : `${hours}h`;
+}
+
+function touchActiveTask(sessionId: string): void {
+  const task = getState().activeTasks.get(sessionId);
+  if (task) {
+    task.lastActivityAt = Date.now();
+  }
+}
+
+async function maybeHandleBusySession(
+  adapter: BaseChannelAdapter,
+  msg: InboundMessage,
+  sessionId: string,
+): Promise<boolean> {
+  const state = getState();
+  const task = state.activeTasks.get(sessionId);
+  if (!task) return false;
+
+  const now = Date.now();
+  const idleMs = now - task.lastActivityAt;
+  const staleMs = getActiveTaskStaleMs();
+
+  if (idleMs >= staleMs) {
+    task.abortController.abort();
+    state.activeTasks.delete(sessionId);
+    await deliver(adapter, {
+      address: msg.address,
+      text: `The previous task looked stuck after ${formatDuration(idleMs)} without progress. I stopped it and will continue with your latest message.`,
+      parseMode: 'plain',
+      replyToMessageId: msg.messageId,
+    });
+    return false;
+  }
+
+  await deliver(adapter, {
+    address: msg.address,
+    text: `Current task is still running (${formatDuration(now - task.startedAt)} elapsed, last progress ${formatDuration(idleMs)} ago). Send /stop to interrupt it or /new to start a fresh session.`,
+    parseMode: 'plain',
+    replyToMessageId: msg.messageId,
+  });
+
+  if (msg.updateId != null && adapter.acknowledgeUpdate) {
+    adapter.acknowledgeUpdate(msg.updateId);
+  }
+  return true;
 }
 
 /**
@@ -400,6 +468,9 @@ function runAdapterLoop(adapter: BaseChannelAdapter): void {
           await handleMessage(adapter, msg);
         } else {
           const binding = router.resolve(msg.address);
+          if (await maybeHandleBusySession(adapter, msg, binding.codepilotSessionId)) {
+            continue;
+          }
           // Fire-and-forget into session lock — loop continues to accept
           // messages for other sessions immediately.
           processWithSessionLock(binding.codepilotSessionId, () =>
@@ -595,7 +666,11 @@ async function handleMessage(
   // Create an AbortController so /stop can cancel this task externally
   const taskAbort = new AbortController();
   const state = getState();
-  state.activeTasks.set(binding.codepilotSessionId, taskAbort);
+  state.activeTasks.set(binding.codepilotSessionId, {
+    abortController: taskAbort,
+    startedAt: Date.now(),
+    lastActivityAt: Date.now(),
+  });
 
   // ── Streaming preview setup ──────────────────────────────────
   let previewState: StreamingPreviewState | null = null;
@@ -670,7 +745,9 @@ async function handleMessage(
     try { adapter.onStreamText!(msg.address.chatId, fullText); } catch { /* non-critical */ }
   } : undefined;
 
-  const onToolEvent = hasStreamingCards ? (toolId: string, toolName: string, status: 'running' | 'complete' | 'error') => {
+  const onToolEvent = (toolId: string, toolName: string, status: 'running' | 'complete' | 'error') => {
+    touchActiveTask(binding.codepilotSessionId);
+    if (!hasStreamingCards) return;
     if (toolName) {
       toolCallTracker.set(toolId, { id: toolId, name: toolName, status });
     } else {
@@ -681,13 +758,14 @@ async function handleMessage(
     try {
       adapter.onToolEvent!(msg.address.chatId, Array.from(toolCallTracker.values()));
     } catch { /* non-critical */ }
-  } : undefined;
+  };
 
-  // Combined partial text callback: streaming preview + streaming cards
-  const onPartialText = (previewOnPartialText || onStreamCardText) ? (fullText: string) => {
+  // Combined partial text callback: task heartbeat + preview + streaming cards
+  const onPartialText = (fullText: string) => {
+    touchActiveTask(binding.codepilotSessionId);
     if (previewOnPartialText) previewOnPartialText(fullText);
     if (onStreamCardText) onStreamCardText(fullText);
-  } : undefined;
+  };
 
   try {
     // Pass permission callback so requests are forwarded to IM immediately
@@ -696,6 +774,7 @@ async function handleMessage(
     const promptText = text || (hasAttachments ? 'Describe this image.' : '');
 
     const result = await engine.processMessage(binding, promptText, async (perm) => {
+      touchActiveTask(binding.codepilotSessionId);
       await broker.forwardPermissionRequest(
         adapter,
         msg.address,
@@ -836,7 +915,7 @@ async function handleCommand(
       const st = getState();
       const oldTask = st.activeTasks.get(oldBinding.codepilotSessionId);
       if (oldTask) {
-        oldTask.abort();
+        oldTask.abortController.abort();
         st.activeTasks.delete(oldBinding.codepilotSessionId);
       }
 
@@ -932,7 +1011,7 @@ async function handleCommand(
       const st = getState();
       const taskAbort = st.activeTasks.get(binding.codepilotSessionId);
       if (taskAbort) {
-        taskAbort.abort();
+        taskAbort.abortController.abort();
         st.activeTasks.delete(binding.codepilotSessionId);
         response = 'Stopping current task...';
       } else {
@@ -1020,4 +1099,4 @@ export function computeSdkSessionUpdate(
 // Exposed so integration tests can exercise handleMessage directly
 // without wiring up the full adapter loop.
 /** @internal */
-export const _testOnly = { handleMessage };
+export const _testOnly = { handleMessage, maybeHandleBusySession };


### PR DESCRIPTION
## Summary

This PR improves bridge behavior for long-running or stuck chat sessions.

It adds explicit busy-session handling so follow-up messages in the same session are not silently queued, and it makes the Feishu adapter gracefully fall back when CardKit v2 APIs are unavailable.

## Changes

- track active task state with start time and last activity time
- return an explicit busy-session reply instead of silently queueing same-session follow-up messages
- abort stale active tasks after the configured idle window
- degrade Feishu streaming-card behavior when CardKit APIs are unavailable
- add unit tests for busy-session and stale-task behavior

## Why

Previously, if one task in a chat session ran for a long time or got stuck, later user messages in the same session could appear to receive no response because they were queued invisibly behind the first task.

In Feishu, when CardKit APIs were unavailable, the adapter could repeatedly retry the streaming-card path and keep producing noisy errors instead of falling back cleanly.

## Validation

- `npm test`

## Notes

This PR targets the core `Claude-to-IM` repository.

The skill-side Codex abort-signal fix is handled separately in the `Claude-to-IM-skill` repository.

## 摘要

这个 PR 改进了 bridge 在长任务或卡住任务场景下的会话行为。

主要包括两部分：

1. 为同一 session 下的后续消息增加显式 busy-session 提示，避免静默排队
2. 当 Feishu 的 CardKit v2 API 不可用时，adapter 自动降级，而不是反复尝试流式卡片并持续报错

## 变更内容

- 增加 active task 状态跟踪，包括开始时间和最近活动时间
- 同一 session 已有运行中任务时，返回明确提示，而不是把后续消息静默排队
- 对长时间无进展的活跃任务按配置阈值进行 stale 判定并中断
- Feishu 在 CardKit API 不可用时自动降级流式卡片逻辑
- 增加 busy-session 和 stale-task 的单元测试

## 为什么要改

之前如果一个聊天 session 中有任务运行很久或者卡住，后续消息在同一 session 下会被静默排队。用户看到的现象就是“机器人不再回复”，但实际上消息只是被卡在队列里。

另外在 Feishu 环境中，如果 CardKit API 不可用，adapter 会不断重试流式卡片路径，导致日志持续报错，而不是平稳回退到普通回复模式。

## 验证

- `npm test`

## 说明

这个 PR 只针对核心仓库 `Claude-to-IM`。

skill 侧关于 Codex abort signal 传递的问题，已在 `Claude-to-IM-skill` 仓库单独处理。
