### PR TITLE
feat: inbound file reception (PDF/docs) and outbound file sending for Feishu

### DIFF
--- a/package-lock.json
+++ b/package-lock.json
@@ -10,6 +10,7 @@
       "dependencies": {
         "@anthropic-ai/claude-agent-sdk": "^0.2.62",
         "@larksuiteoapi/node-sdk": "^1.59.0",
+        "content-guard": "file:../../projects/content-guard",
         "discord.js": "^14.25.1",
         "markdown-it": "^14.1.1",
         "ws": "^8.18.0"
@@ -18,6 +19,20 @@
         "@types/markdown-it": "^14.1.2",
         "@types/node": "^22.0.0",
         "@types/ws": "^8.5.0",
+        "tsx": "^4.21.0",
+        "typescript": "^5"
+      },
+      "engines": {
+        "node": ">=20"
+      }
+    },
+    "../../projects/content-guard": {
+      "version": "1.0.0",
+      "bin": {
+        "content-guard": "dist/cli.js"
+      },
+      "devDependencies": {
+        "@types/node": "^25.5.2",
         "tsx": "^4.21.0",
         "typescript": "^5"
       },
@@ -1152,6 +1167,10 @@
       "engines": {
         "node": ">= 0.8"
       }
+    },
+    "node_modules/content-guard": {
+      "resolved": "../../projects/content-guard",
+      "link": true
     },
     "node_modules/delayed-stream": {
       "version": "1.0.0",

--- a/package-lock.json
+++ b/package-lock.json
@@ -9,7 +9,7 @@
       "version": "0.1.0",
       "dependencies": {
         "@anthropic-ai/claude-agent-sdk": "^0.2.62",
-        "@larksuiteoapi/node-sdk": "^1.59.0",
+        "@larksuiteoapi/node-sdk": "^1.60.0",
         "content-guard": "file:../../projects/content-guard",
         "discord.js": "^14.25.1",
         "markdown-it": "^14.1.1",
@@ -940,9 +940,9 @@
       }
     },
     "node_modules/@larksuiteoapi/node-sdk": {
-      "version": "1.59.0",
-      "resolved": "https://registry.npmjs.org/@larksuiteoapi/node-sdk/-/node-sdk-1.59.0.tgz",
-      "integrity": "sha512-sBpkruTvZDOxnVtoTbepWKRX0j1Y1ZElQYu0x7+v088sI9pcpbVp6ZzCGn62dhrKPatzNyCJyzYCPXPYQWccrA==",
+      "version": "1.60.0",
+      "resolved": "https://registry.npmjs.org/@larksuiteoapi/node-sdk/-/node-sdk-1.60.0.tgz",
+      "integrity": "sha512-MS1eXx7K6HHIyIcCBkJLb21okoa8ZatUGQWZaCCUePm6a37RWFmT6ZKlKvHxAanSX26wNuNlwP0RhgscsE+T6g==",
       "license": "MIT",
       "dependencies": {
         "axios": "~1.13.3",

--- a/package.json
+++ b/package.json
@@ -27,7 +27,10 @@
       "import": "./dist/lib/bridge/security/*.js"
     }
   },
-  "files": ["dist", "src/lib"],
+  "files": [
+    "dist",
+    "src/lib"
+  ],
   "scripts": {
     "build": "tsc -p tsconfig.build.json",
     "prepare": "npm run build",
@@ -38,6 +41,7 @@
   },
   "dependencies": {
     "@anthropic-ai/claude-agent-sdk": "^0.2.62",
+    "content-guard": "file:../../projects/content-guard",
     "@larksuiteoapi/node-sdk": "^1.59.0",
     "discord.js": "^14.25.1",
     "markdown-it": "^14.1.1",
@@ -45,8 +49,8 @@
   },
   "devDependencies": {
     "@types/markdown-it": "^14.1.2",
-    "@types/ws": "^8.5.0",
     "@types/node": "^22.0.0",
+    "@types/ws": "^8.5.0",
     "tsx": "^4.21.0",
     "typescript": "^5"
   },

--- a/package.json
+++ b/package.json
@@ -41,8 +41,8 @@
   },
   "dependencies": {
     "@anthropic-ai/claude-agent-sdk": "^0.2.62",
+    "@larksuiteoapi/node-sdk": "^1.60.0",
     "content-guard": "file:../../projects/content-guard",
-    "@larksuiteoapi/node-sdk": "^1.59.0",
     "discord.js": "^14.25.1",
     "markdown-it": "^14.1.1",
     "ws": "^8.18.0"

--- a/scripts/build.js
+++ b/scripts/build.js
@@ -1,0 +1,26 @@
+import * as esbuild from 'esbuild';
+
+await esbuild.build({
+  entryPoints: ['src/main.ts'],
+  bundle: true,
+  platform: 'node',
+  format: 'esm',
+  target: 'node20',
+  outfile: 'dist/daemon.mjs',
+  external: [
+    // SDK must stay external — it spawns a CLI subprocess and resolves
+    // dist/cli.js relative to its own package location. Bundling it
+    // breaks that path resolution.
+    '@anthropic-ai/claude-agent-sdk',
+    '@openai/codex-sdk',
+    // discord.js optional native deps
+    'bufferutil', 'utf-8-validate', 'zlib-sync', 'erlpack',
+    // Node.js built-ins
+    'fs', 'path', 'os', 'crypto', 'http', 'https', 'net', 'tls',
+    'stream', 'events', 'url', 'util', 'child_process', 'worker_threads',
+    'node:*',
+  ],
+  banner: { js: "import { createRequire } from 'module'; const require = createRequire(import.meta.url);" },
+});
+
+console.log('Built dist/daemon.mjs');

--- a/scripts/migrate-to-multi-bot.sh
+++ b/scripts/migrate-to-multi-bot.sh
@@ -1,0 +1,218 @@
+#!/usr/bin/env bash
+set -euo pipefail
+
+# Migrate claude-to-im single-bot data into a per-bot data directory.
+# Usage: ./scripts/migrate-to-multi-bot.sh --bot-name <name> [--dry-run]
+
+usage() {
+  echo "Usage: $0 --bot-name <name> [--dry-run]"
+}
+
+log() {
+  echo "==> $*"
+}
+
+dry_log() {
+  echo "[dry-run] $*"
+}
+
+fail() {
+  echo "ERROR: $*" >&2
+  exit 1
+}
+
+run_or_print() {
+  if [[ "$DRY_RUN" == true ]]; then
+    dry_log "$*"
+  else
+    "$@"
+  fi
+}
+
+BOT_NAME=""
+DRY_RUN=false
+CTI_HOME="${CTI_HOME:-$HOME/.claude-to-im}"
+
+while [[ $# -gt 0 ]]; do
+  case "$1" in
+    --bot-name)
+      [[ $# -ge 2 ]] || fail "--bot-name requires a value"
+      BOT_NAME="$2"
+      shift 2
+      ;;
+    --dry-run)
+      DRY_RUN=true
+      shift
+      ;;
+    -h|--help)
+      usage
+      exit 0
+      ;;
+    *)
+      fail "Unknown option: $1"
+      ;;
+  esac
+done
+
+[[ -n "$BOT_NAME" ]] || { usage; fail "--bot-name is required"; }
+[[ "$BOT_NAME" =~ ^[A-Za-z0-9][A-Za-z0-9-]*$ ]] || fail "--bot-name must use alphanumeric characters and dashes only, and must start with an alphanumeric character"
+
+DATA_DIR="$CTI_HOME/data"
+BOT_DIR="$DATA_DIR/$BOT_NAME"
+TIMESTAMP="$(date +%Y%m%d%H%M%S)"
+BACKUP_DIR="$DATA_DIR.bak.$TIMESTAMP"
+DATA_FILES=(
+  sessions.json
+  bindings.json
+  permissions.json
+  offsets.json
+  dedup.json
+  audit.json
+)
+
+command -v shasum >/dev/null 2>&1 || fail "shasum is required"
+command -v node >/dev/null 2>&1 || fail "node is required to update bindings.json"
+[[ -d "$DATA_DIR" ]] || fail "Data directory not found: $DATA_DIR"
+[[ ! -e "$BOT_DIR" ]] || fail "Target bot data directory already exists: $BOT_DIR"
+[[ ! -e "$BACKUP_DIR" ]] || fail "Backup path already exists: $BACKUP_DIR"
+
+log "Migration settings"
+echo "CTI_HOME:  $CTI_HOME"
+echo "Data dir:  $DATA_DIR"
+echo "Bot name:  $BOT_NAME"
+echo "Target:    $BOT_DIR"
+echo "Backup:    $BACKUP_DIR"
+echo "Dry run:   $DRY_RUN"
+echo
+
+log "Recording source checksums"
+CHECKSUM_FILE="$(mktemp "${TMPDIR:-/tmp}/cti-migrate-checksums.XXXXXX")"
+trap 'rm -f "$CHECKSUM_FILE"' EXIT
+
+for filename in "${DATA_FILES[@]}"; do
+  src="$DATA_DIR/$filename"
+  if [[ -f "$src" ]]; then
+    shasum -a 256 "$src" >> "$CHECKSUM_FILE"
+    echo "Found: $filename"
+  else
+    echo "Missing, skip: $filename"
+  fi
+done
+
+if [[ -d "$DATA_DIR/messages" ]]; then
+  while IFS= read -r -d '' message_file; do
+    shasum -a 256 "$message_file" >> "$CHECKSUM_FILE"
+  done < <(find "$DATA_DIR/messages" -type f -print0 | sort -z)
+  echo "Found: messages/"
+else
+  echo "Missing, skip: messages/"
+fi
+echo
+
+log "Backing up data directory"
+run_or_print cp -a "$DATA_DIR" "$BACKUP_DIR"
+echo
+
+log "Creating per-bot data directory"
+run_or_print mkdir -p "$BOT_DIR"
+echo
+
+log "Copying data files"
+for filename in "${DATA_FILES[@]}"; do
+  src="$DATA_DIR/$filename"
+  dst="$BOT_DIR/$filename"
+  if [[ -f "$src" ]]; then
+    run_or_print cp -a "$src" "$dst"
+  fi
+done
+
+if [[ -d "$DATA_DIR/messages" ]]; then
+  run_or_print cp -a "$DATA_DIR/messages" "$BOT_DIR/messages"
+fi
+echo
+
+if [[ "$DRY_RUN" == true ]]; then
+  log "Updating copied bindings.json"
+  dry_log "Would rewrite keys in $BOT_DIR/bindings.json from channelType:chatId to channelType:$BOT_NAME:chatId and add botName=\"$BOT_NAME\""
+  echo
+  log "Verifying source checksums"
+  dry_log "Would verify original source files are unchanged with shasum -a 256 -c"
+  echo
+  log "Dry run complete. No files were changed."
+  exit 0
+fi
+
+log "Verifying copied files before mutation"
+for filename in "${DATA_FILES[@]}"; do
+  src="$DATA_DIR/$filename"
+  dst="$BOT_DIR/$filename"
+  if [[ -f "$src" ]]; then
+    src_sum="$(shasum -a 256 "$src" | awk '{print $1}')"
+    dst_sum="$(shasum -a 256 "$dst" | awk '{print $1}')"
+    [[ "$src_sum" == "$dst_sum" ]] || fail "Checksum mismatch after copying $filename"
+  fi
+done
+
+if [[ -d "$DATA_DIR/messages" ]]; then
+  while IFS= read -r -d '' src; do
+    rel="${src#"$DATA_DIR/messages/"}"
+    dst="$BOT_DIR/messages/$rel"
+    [[ -f "$dst" ]] || fail "Missing copied message file: $dst"
+    src_sum="$(shasum -a 256 "$src" | awk '{print $1}')"
+    dst_sum="$(shasum -a 256 "$dst" | awk '{print $1}')"
+    [[ "$src_sum" == "$dst_sum" ]] || fail "Checksum mismatch after copying messages/$rel"
+  done < <(find "$DATA_DIR/messages" -type f -print0)
+fi
+echo
+
+log "Updating copied bindings.json"
+BINDINGS="$BOT_DIR/bindings.json"
+if [[ -f "$BINDINGS" ]]; then
+  BOT_NAME="$BOT_NAME" BINDINGS="$BINDINGS" node <<'NODE'
+const fs = require('fs');
+
+const botName = process.env.BOT_NAME;
+const bindingsPath = process.env.BINDINGS;
+const raw = fs.readFileSync(bindingsPath, 'utf8');
+const bindings = raw.trim() ? JSON.parse(raw) : {};
+const migrated = {};
+let changed = 0;
+
+for (const [key, value] of Object.entries(bindings)) {
+  const parts = key.split(':');
+  const nextValue = value && typeof value === 'object' && !Array.isArray(value)
+    ? { ...value, botName }
+    : value;
+
+  if (parts.length === 2) {
+    migrated[`${parts[0]}:${botName}:${parts[1]}`] = nextValue;
+    changed += 1;
+  } else {
+    migrated[key] = nextValue;
+  }
+}
+
+fs.writeFileSync(bindingsPath, JSON.stringify(migrated, null, 2) + '\n');
+console.log(`Updated ${changed} binding key(s) in ${bindingsPath}`);
+NODE
+else
+  echo "No bindings.json found in copied data; skipped binding rewrite."
+fi
+echo
+
+log "Verifying original source files are unchanged"
+if [[ -s "$CHECKSUM_FILE" ]]; then
+  shasum -a 256 -c "$CHECKSUM_FILE"
+else
+  echo "No source files were present for checksum verification."
+fi
+echo
+
+log "Migration complete"
+echo "Original data was not deleted."
+echo "Backup created: $BACKUP_DIR"
+echo "Per-bot data:   $BOT_DIR"
+echo
+echo "Manual cleanup after verifying the daemon works:"
+echo "  rm -f \"$DATA_DIR\"/{sessions.json,bindings.json,permissions.json,offsets.json,dedup.json,audit.json}"
+echo "  rm -rf \"$DATA_DIR/messages\""

--- a/src/__tests__/unit/adapter-instance-key.test.ts
+++ b/src/__tests__/unit/adapter-instance-key.test.ts
@@ -1,0 +1,24 @@
+import { describe, test } from 'node:test';
+import assert from 'node:assert/strict';
+import { BaseChannelAdapter } from '../../lib/bridge/channel-adapter';
+import type { ChannelType, InboundMessage, OutboundMessage, SendResult } from '../../lib/bridge/types';
+
+class TestAdapter extends BaseChannelAdapter {
+  readonly channelType: ChannelType = 'test-channel';
+
+  async start(): Promise<void> {}
+  async stop(): Promise<void> {}
+  isRunning(): boolean { return false; }
+  async consumeOne(): Promise<InboundMessage | null> { return null; }
+  async send(_message: OutboundMessage): Promise<SendResult> { return { ok: true }; }
+  validateConfig(): string | null { return null; }
+  isAuthorized(_userId: string, _chatId: string): boolean { return true; }
+}
+
+describe('BaseChannelAdapter instanceKey', () => {
+  test('defaults to channelType', () => {
+    const adapter = new TestAdapter();
+    assert.equal(adapter.instanceKey, adapter.channelType);
+    assert.equal(adapter.instanceKey, 'test-channel');
+  });
+});

--- a/src/__tests__/unit/bridge-feishu-adapter.test.ts
+++ b/src/__tests__/unit/bridge-feishu-adapter.test.ts
@@ -1,0 +1,94 @@
+import { describe, test, beforeEach } from 'node:test';
+import assert from 'node:assert/strict';
+import { initBridgeContext } from '../../lib/bridge/context';
+import { FeishuAdapter } from '../../lib/bridge/adapters/feishu-adapter';
+import type { BridgeStore } from '../../lib/bridge/host';
+import type { FeishuBotConfig } from '../../lib/bridge/types';
+
+function createMockStore(settings: Record<string, string> = {}) {
+  return {
+    getSetting: (key: string) => settings[key] ?? null,
+    getChannelBinding: () => null,
+    upsertChannelBinding: () => ({} as any),
+    updateChannelBinding: () => {},
+    listChannelBindings: () => [],
+    getSession: () => null,
+    createSession: () => ({ id: 'session-1', working_directory: '', model: '' }),
+    updateSessionProviderId: () => {},
+    addMessage: () => {},
+    getMessages: () => ({ messages: [] }),
+    acquireSessionLock: () => true,
+    renewSessionLock: () => {},
+    releaseSessionLock: () => {},
+    setSessionRuntimeStatus: () => {},
+    updateSdkSessionId: () => {},
+    updateSessionModel: () => {},
+    syncSdkTasks: () => {},
+    getProvider: () => undefined,
+    getDefaultProviderId: () => null,
+    insertAuditLog: () => {},
+    checkDedup: () => false,
+    insertDedup: () => {},
+    cleanupExpiredDedup: () => {},
+    insertOutboundRef: () => {},
+    insertPermissionLink: () => {},
+    getPermissionLink: () => null,
+    markPermissionLinkResolved: () => false,
+    listPendingPermissionLinksByChat: () => [],
+    getChannelOffset: () => '0',
+    setChannelOffset: () => {},
+  };
+}
+
+function setupContext(store: BridgeStore): void {
+  delete (globalThis as Record<string, unknown>)['__bridge_context__'];
+  initBridgeContext({
+    store,
+    llm: { streamChat: () => new ReadableStream() },
+    permissions: { resolvePendingPermission: () => false },
+    lifecycle: {},
+  });
+}
+
+function createConfig(overrides: Partial<FeishuBotConfig> = {}): FeishuBotConfig {
+  return {
+    name: 'ccbot',
+    appId: 'cli_test',
+    appSecret: 'secret_test',
+    ...overrides,
+  };
+}
+
+describe('FeishuAdapter multi-instance config', () => {
+  let store: BridgeStore;
+
+  beforeEach(() => {
+    store = createMockStore({ bridge_default_work_dir: '/global/default' }) as unknown as BridgeStore;
+    setupContext(store);
+  });
+
+  test('instanceKey includes bot name and exposes botStore', () => {
+    const adapter = new FeishuAdapter(createConfig({ name: 'jason' }), store);
+
+    assert.equal(adapter.instanceKey, 'feishu:jason');
+    assert.equal(adapter.botStore, store);
+  });
+
+  test('resolveWorkingDirectory prefers user override before bot and global defaults', () => {
+    const adapter = new FeishuAdapter(createConfig({
+      workingDirectory: '/bot/default',
+      userOverrides: new Map([
+        ['ou_1', { workingDirectory: '/users/ou_1' }],
+      ]),
+    }), store);
+
+    assert.equal(adapter.resolveWorkingDirectory('ou_1'), '/users/ou_1');
+    assert.equal(adapter.resolveWorkingDirectory('ou_2'), '/bot/default');
+  });
+
+  test('resolveWorkingDirectory falls back to global default when bot has no working directory', () => {
+    const adapter = new FeishuAdapter(createConfig(), store);
+
+    assert.equal(adapter.resolveWorkingDirectory('ou_1'), '/global/default');
+  });
+});

--- a/src/__tests__/unit/bridge-manager.test.ts
+++ b/src/__tests__/unit/bridge-manager.test.ts
@@ -11,7 +11,9 @@
 import { describe, it, beforeEach } from 'node:test';
 import assert from 'node:assert/strict';
 import { initBridgeContext } from '../../lib/bridge/context';
+import type { BaseChannelAdapter } from '../../lib/bridge/channel-adapter';
 import type { BridgeStore, LifecycleHooks } from '../../lib/bridge/host';
+import type { InboundMessage, OutboundMessage, SendResult } from '../../lib/bridge/types';
 
 // ── Test the session lock mechanism directly ────────────────
 // We test the processWithSessionLock pattern by extracting its logic.
@@ -131,6 +133,73 @@ describe('bridge-manager lifecycle', () => {
     assert.equal(status.running, false);
     assert.equal(status.adapters.length, 0);
   });
+
+  it('registers and looks up adapters by instanceKey', async () => {
+    const store = createMinimalStore({ remote_bridge_enabled: 'false' });
+    initBridgeContext({
+      store,
+      llm: { streamChat: () => new ReadableStream() },
+      permissions: { resolvePendingPermission: () => false },
+      lifecycle: {},
+    });
+
+    const { registerAdapter, getAdapter, getStatus } = await import('../../lib/bridge/bridge-manager');
+    const adapter = createMockAdapter({ channelType: 'feishu', instanceKey: 'feishu:ccbot' });
+
+    registerAdapter(adapter);
+
+    assert.equal(getAdapter('feishu:ccbot'), adapter);
+    assert.equal(getAdapter('feishu'), undefined);
+    assert.equal(getStatus().adapters[0].instanceKey, 'feishu:ccbot');
+  });
+
+  it('derives the store from adapter.botStore for commands and permission callbacks', async () => {
+    const globalStore = createTrackingStore('global');
+    const botStore = createTrackingStore('ccbot');
+    initBridgeContext({
+      store: globalStore as unknown as BridgeStore,
+      llm: { streamChat: () => new ReadableStream() },
+      permissions: { resolvePendingPermission: () => true },
+      lifecycle: {},
+    });
+
+    const { _testOnly } = await import('../../lib/bridge/bridge-manager');
+    const adapter = createMockAdapter({
+      channelType: 'feishu',
+      instanceKey: 'feishu:ccbot',
+      botStore: botStore as unknown as BridgeStore,
+    });
+
+    await _testOnly.handleMessage(adapter, {
+      messageId: 'msg-new',
+      address: { channelType: 'feishu', botName: 'ccbot', chatId: 'chat-1' },
+      text: '/new /tmp',
+      timestamp: Date.now(),
+    });
+
+    assert.ok(botStore.createdSessions.length > 0);
+    assert.equal(globalStore.createdSessions.length, 0);
+
+    botStore.permissionLink = {
+      permissionRequestId: 'perm-1',
+      chatId: 'chat-1',
+      messageId: 'perm-msg-1',
+      resolved: false,
+    };
+
+    await _testOnly.handleMessage(adapter, {
+      messageId: 'msg-callback',
+      address: { channelType: 'feishu', botName: 'ccbot', chatId: 'chat-1' },
+      text: '',
+      callbackData: 'perm:allow:perm-1',
+      callbackMessageId: 'perm-msg-1',
+      timestamp: Date.now(),
+    });
+
+    assert.deepEqual(botStore.resolvedPermissionIds, ['perm-1']);
+    assert.deepEqual(globalStore.resolvedPermissionIds, []);
+    assert.equal(adapter.sentMessages.length, 2);
+  });
 });
 
 function createMinimalStore(settings: Record<string, string> = {}): BridgeStore {
@@ -166,4 +235,88 @@ function createMinimalStore(settings: Record<string, string> = {}): BridgeStore 
     getChannelOffset: () => '0',
     setChannelOffset: () => {},
   };
+}
+
+function createTrackingStore(name: string) {
+  const createdSessions: string[] = [];
+  const resolvedPermissionIds: string[] = [];
+  let permissionLink: any = null;
+
+  return {
+    name,
+    createdSessions,
+    resolvedPermissionIds,
+    get permissionLink() { return permissionLink; },
+    set permissionLink(value: any) { permissionLink = value; },
+    getSetting: (key: string) => key === 'bridge_default_work_dir' ? '/default' : null,
+    getChannelBinding: () => null,
+    upsertChannelBinding: (binding: any) => ({
+      id: `${name}-binding`,
+      active: true,
+      createdAt: '',
+      updatedAt: '',
+      ...binding,
+    }),
+    updateChannelBinding: () => {},
+    listChannelBindings: () => [],
+    getSession: () => null,
+    createSession: () => {
+      const id = `${name}-session-${createdSessions.length + 1}`;
+      createdSessions.push(id);
+      return { id, working_directory: '/tmp', model: '' };
+    },
+    updateSessionProviderId: () => {},
+    addMessage: () => {},
+    getMessages: () => ({ messages: [] }),
+    acquireSessionLock: () => true,
+    renewSessionLock: () => {},
+    releaseSessionLock: () => {},
+    setSessionRuntimeStatus: () => {},
+    updateSdkSessionId: () => {},
+    updateSessionModel: () => {},
+    syncSdkTasks: () => {},
+    getProvider: () => undefined,
+    getDefaultProviderId: () => null,
+    insertAuditLog: () => {},
+    checkDedup: () => false,
+    insertDedup: () => {},
+    cleanupExpiredDedup: () => {},
+    insertOutboundRef: () => {},
+    insertPermissionLink: () => {},
+    getPermissionLink: (permissionRequestId: string) =>
+      permissionLink?.permissionRequestId === permissionRequestId ? permissionLink : null,
+    markPermissionLinkResolved: (permissionRequestId: string) => {
+      if (!permissionLink || permissionLink.permissionRequestId !== permissionRequestId) return false;
+      resolvedPermissionIds.push(permissionRequestId);
+      permissionLink.resolved = true;
+      return true;
+    },
+    listPendingPermissionLinksByChat: () => [],
+    getChannelOffset: () => '0',
+    setChannelOffset: () => {},
+  };
+}
+
+function createMockAdapter(opts: {
+  channelType: string;
+  instanceKey: string;
+  botStore?: BridgeStore;
+}): BaseChannelAdapter & { sentMessages: OutboundMessage[]; botStore?: BridgeStore } {
+  const sentMessages: OutboundMessage[] = [];
+  return {
+    channelType: opts.channelType,
+    get instanceKey() { return opts.instanceKey; },
+    botStore: opts.botStore,
+    sentMessages,
+    start: async () => {},
+    stop: async () => {},
+    isRunning: () => true,
+    consumeOne: async (): Promise<InboundMessage | null> => null,
+    send: async (message: OutboundMessage): Promise<SendResult> => {
+      sentMessages.push(message);
+      return { ok: true, messageId: `sent-${sentMessages.length}` };
+    },
+    validateConfig: () => null,
+    isAuthorized: () => true,
+  } as unknown as BaseChannelAdapter & { sentMessages: OutboundMessage[]; botStore?: BridgeStore };
 }

--- a/src/__tests__/unit/bridge-outbound-files.test.ts
+++ b/src/__tests__/unit/bridge-outbound-files.test.ts
@@ -1,0 +1,74 @@
+import { describe, it } from 'node:test';
+import assert from 'node:assert/strict';
+import { extractCreatedFiles, isSendableFile, isImageFile } from '../../lib/bridge/conversation-engine.js';
+
+describe('extractCreatedFiles', () => {
+  it('extracts created file paths from Edit tool input', () => {
+    const input = {
+      files: [
+        { kind: 'create', path: '/tmp/chart.png' },
+        { kind: 'modify', path: '/src/index.ts' },
+        { kind: 'create', path: '/tmp/report.pdf' },
+      ],
+    };
+    const result = extractCreatedFiles('Edit', input);
+    assert.deepStrictEqual(result, ['/tmp/chart.png', '/tmp/report.pdf']);
+  });
+
+  it('returns empty array for non-Edit tools', () => {
+    const result = extractCreatedFiles('Bash', { command: 'ls' });
+    assert.deepStrictEqual(result, []);
+  });
+
+  it('returns empty array when input has no files', () => {
+    const result = extractCreatedFiles('Edit', { text: 'hello' });
+    assert.deepStrictEqual(result, []);
+  });
+});
+
+describe('isSendableFile', () => {
+  it('recognizes image extensions', () => {
+    assert.ok(isSendableFile('/tmp/chart.png'));
+    assert.ok(isSendableFile('/tmp/photo.jpg'));
+    assert.ok(isSendableFile('/tmp/icon.webp'));
+    assert.ok(isSendableFile('/tmp/anim.gif'));
+  });
+
+  it('recognizes document extensions', () => {
+    assert.ok(isSendableFile('/tmp/report.pdf'));
+    assert.ok(isSendableFile('/tmp/data.csv'));
+    assert.ok(isSendableFile('/tmp/archive.zip'));
+    assert.ok(isSendableFile('/tmp/slides.pptx'));
+  });
+
+  it('rejects source code files', () => {
+    assert.ok(!isSendableFile('/src/index.ts'));
+    assert.ok(!isSendableFile('/src/main.py'));
+    assert.ok(!isSendableFile('/config.json'));
+    assert.ok(!isSendableFile('/README.md'));
+  });
+});
+
+describe('isImageFile', () => {
+  it('returns true for image extensions', () => {
+    assert.ok(isImageFile('/tmp/chart.png'));
+    assert.ok(isImageFile('/tmp/photo.jpg'));
+    assert.ok(isImageFile('/tmp/image.jpeg'));
+    assert.ok(isImageFile('/tmp/anim.gif'));
+    assert.ok(isImageFile('/tmp/icon.webp'));
+    assert.ok(isImageFile('/tmp/bitmap.bmp'));
+    assert.ok(isImageFile('/tmp/scan.tiff'));
+    assert.ok(isImageFile('/tmp/favicon.ico'));
+    assert.ok(isImageFile('/tmp/logo.svg'));
+  });
+
+  it('returns false for document extensions', () => {
+    assert.ok(!isImageFile('/tmp/report.pdf'));
+    assert.ok(!isImageFile('/tmp/data.csv'));
+  });
+
+  it('returns false for source code extensions', () => {
+    assert.ok(!isImageFile('/src/index.ts'));
+    assert.ok(!isImageFile('/src/main.py'));
+  });
+});

--- a/src/__tests__/unit/config-multi-bot.test.ts
+++ b/src/__tests__/unit/config-multi-bot.test.ts
@@ -1,0 +1,83 @@
+import { describe, test } from 'node:test';
+import assert from 'node:assert/strict';
+import { parseFeishuBotConfigs } from '../../config';
+
+describe('parseFeishuBotConfigs', () => {
+  test('parses multiple bots', () => {
+    const env = new Map<string, string>([
+      ['CTI_FEISHU_BOTS_0_NAME', 'ccbot'],
+      ['CTI_FEISHU_BOTS_0_APP_ID', 'cli_aaa'],
+      ['CTI_FEISHU_BOTS_0_APP_SECRET', 'secret_aaa'],
+      ['CTI_FEISHU_BOTS_0_DOMAIN', 'feishu'],
+      ['CTI_FEISHU_BOTS_0_ALLOWED_USERS', 'ou_1,ou_2'],
+      ['CTI_FEISHU_BOTS_0_REQUIRE_MENTION', 'false'],
+      ['CTI_FEISHU_BOTS_0_WORKING_DIR', '~/Claude Code'],
+      ['CTI_FEISHU_BOTS_0_GROUP_POLICY', 'allowlist'],
+      ['CTI_FEISHU_BOTS_0_GROUP_ALLOW_FROM', 'oc_xxx'],
+      ['CTI_FEISHU_BOTS_0_USER_ou_2_WORKING_DIR', '~/workspace-aixin'],
+      ['CTI_FEISHU_BOTS_1_NAME', 'jason'],
+      ['CTI_FEISHU_BOTS_1_APP_ID', 'cli_bbb'],
+      ['CTI_FEISHU_BOTS_1_APP_SECRET', 'secret_bbb'],
+      ['CTI_FEISHU_BOTS_1_WORKING_DIR', '~/tenant-jason'],
+    ]);
+
+    const bots = parseFeishuBotConfigs(env);
+    assert.equal(bots.length, 2);
+
+    assert.equal(bots[0].name, 'ccbot');
+    assert.equal(bots[0].appId, 'cli_aaa');
+    assert.deepEqual(bots[0].allowedUsers, ['ou_1', 'ou_2']);
+    assert.equal(bots[0].requireMention, false);
+    assert.equal(bots[0].domain, 'feishu');
+    assert.equal(bots[0].groupPolicy, 'allowlist');
+    assert.deepEqual(bots[0].groupAllowFrom, ['oc_xxx']);
+    assert.equal(bots[0].workingDirectory, '~/Claude Code');
+    assert.equal(bots[0].userOverrides?.get('ou_2')?.workingDirectory, '~/workspace-aixin');
+
+    assert.equal(bots[1].name, 'jason');
+    assert.equal(bots[1].appId, 'cli_bbb');
+    assert.equal(bots[1].workingDirectory, '~/tenant-jason');
+    assert.equal(bots[1].domain, undefined);
+  });
+
+  test('throws when NAME is missing', () => {
+    const env = new Map<string, string>([
+      ['CTI_FEISHU_BOTS_0_APP_ID', 'cli_xxx'],
+      ['CTI_FEISHU_BOTS_0_APP_SECRET', 'secret'],
+    ]);
+
+    assert.throws(() => parseFeishuBotConfigs(env), /NAME/i);
+  });
+
+  test('throws when APP_ID is missing', () => {
+    const env = new Map<string, string>([
+      ['CTI_FEISHU_BOTS_0_NAME', 'ccbot'],
+      ['CTI_FEISHU_BOTS_0_APP_SECRET', 'secret'],
+    ]);
+
+    assert.throws(() => parseFeishuBotConfigs(env), /APP_ID/i);
+  });
+
+  test('throws when APP_SECRET is missing', () => {
+    const env = new Map<string, string>([
+      ['CTI_FEISHU_BOTS_0_NAME', 'ccbot'],
+      ['CTI_FEISHU_BOTS_0_APP_ID', 'cli_xxx'],
+    ]);
+
+    assert.throws(() => parseFeishuBotConfigs(env), /APP_SECRET/i);
+  });
+
+  test('returns empty array when no bot keys present', () => {
+    const env = new Map<string, string>();
+    assert.deepEqual(parseFeishuBotConfigs(env), []);
+  });
+
+  test('detects legacy format and throws', () => {
+    const env = new Map<string, string>([
+      ['CTI_FEISHU_APP_ID', 'cli_old'],
+      ['CTI_FEISHU_APP_SECRET', 'secret_old'],
+    ]);
+
+    assert.throws(() => parseFeishuBotConfigs(env), /migrate|legacy|旧格式/i);
+  });
+});

--- a/src/__tests__/unit/router-store-param.test.ts
+++ b/src/__tests__/unit/router-store-param.test.ts
@@ -1,0 +1,157 @@
+import { describe, it, beforeEach } from 'node:test';
+import assert from 'node:assert/strict';
+import * as router from '../../lib/bridge/channel-router';
+import type { BridgeSession, BridgeStore } from '../../lib/bridge/host';
+import type { ChannelBinding } from '../../lib/bridge/types';
+
+type TestStore = BridgeStore & {
+  bindings: Map<string, ChannelBinding>;
+  sessions: Map<string, BridgeSession>;
+};
+
+function bindingKey(channelType: string, chatId: string, botName?: string): string {
+  return botName ? `${channelType}:${botName}:${chatId}` : `${channelType}:${chatId}`;
+}
+
+function createStore(defaultCwd = '/tmp/default'): TestStore {
+  const bindings = new Map<string, ChannelBinding>();
+  const sessions = new Map<string, BridgeSession>();
+  let nextId = 1;
+
+  return {
+    bindings,
+    sessions,
+    getSetting(key: string) {
+      if (key === 'bridge_default_work_dir') return defaultCwd;
+      if (key === 'bridge_default_model') return 'gpt-test';
+      if (key === 'bridge_default_provider_id') return '';
+      return null;
+    },
+    getChannelBinding(channelType: string, chatId: string, botName?: string) {
+      return bindings.get(bindingKey(channelType, chatId, botName)) ?? null;
+    },
+    upsertChannelBinding(data) {
+      const key = bindingKey(data.channelType, data.chatId, data.botName);
+      const binding: ChannelBinding = {
+        id: bindings.get(key)?.id ?? `binding-${nextId++}`,
+        channelType: data.channelType,
+        botName: data.botName,
+        chatId: data.chatId,
+        codepilotSessionId: data.codepilotSessionId,
+        sdkSessionId: data.sdkSessionId ?? '',
+        workingDirectory: data.workingDirectory,
+        model: data.model,
+        mode: (data.mode as ChannelBinding['mode']) ?? 'code',
+        active: true,
+        createdAt: new Date(0).toISOString(),
+        updatedAt: new Date(0).toISOString(),
+      };
+      bindings.set(key, binding);
+      return binding;
+    },
+    updateChannelBinding(id: string, updates: Partial<ChannelBinding>) {
+      for (const [key, binding] of bindings) {
+        if (binding.id === id) {
+          bindings.set(key, { ...binding, ...updates });
+          return;
+        }
+      }
+    },
+    listChannelBindings(channelType?: string) {
+      const all = Array.from(bindings.values());
+      return channelType ? all.filter(binding => binding.channelType === channelType) : all;
+    },
+    getSession(id: string) {
+      return sessions.get(id) ?? null;
+    },
+    createSession(name: string, model: string, systemPrompt?: string, cwd?: string, mode?: string) {
+      void name;
+      void systemPrompt;
+      void mode;
+      const session = { id: `session-${nextId++}`, working_directory: cwd ?? '', model };
+      sessions.set(session.id, session);
+      return session;
+    },
+    updateSessionProviderId() {},
+    addMessage() {},
+    getMessages() { return { messages: [] }; },
+    acquireSessionLock() { return true; },
+    renewSessionLock() {},
+    releaseSessionLock() {},
+    setSessionRuntimeStatus() {},
+    updateSdkSessionId() {},
+    updateSessionModel() {},
+    syncSdkTasks() {},
+    getProvider() { return undefined; },
+    getDefaultProviderId() { return null; },
+    insertAuditLog() {},
+    checkDedup() { return false; },
+    insertDedup() {},
+    cleanupExpiredDedup() {},
+    insertOutboundRef() {},
+    insertPermissionLink() {},
+    getPermissionLink() { return null; },
+    markPermissionLinkResolved() { return false; },
+    listPendingPermissionLinksByChat() { return []; },
+    getChannelOffset() { return '0'; },
+    setChannelOffset() {},
+  };
+}
+
+describe('channel-router store parameter', () => {
+  beforeEach(() => {
+    delete (globalThis as Record<string, unknown>)['__bridge_context__'];
+  });
+
+  it('resolve() uses the injected store without bridge context', () => {
+    const store = createStore('/tmp/injected');
+
+    const binding = router.resolve(
+      { channelType: 'feishu', botName: 'bot-a', chatId: 'oc_1', displayName: 'Bot A Chat' },
+      { store },
+    );
+
+    assert.equal(binding.botName, 'bot-a');
+    assert.equal(binding.workingDirectory, '/tmp/injected');
+    assert.equal(store.bindings.size, 1);
+    assert.equal(store.sessions.size, 1);
+  });
+
+  it('resolve() includes botName when reading existing bindings', () => {
+    const store = createStore();
+    const botABinding = router.createBinding(
+      { channelType: 'feishu', botName: 'bot-a', chatId: 'oc_same' },
+      { store, workingDirectory: '/tmp/a' },
+    );
+    const botBBinding = router.createBinding(
+      { channelType: 'feishu', botName: 'bot-b', chatId: 'oc_same' },
+      { store, workingDirectory: '/tmp/b' },
+    );
+
+    const resolvedA = router.resolve(
+      { channelType: 'feishu', botName: 'bot-a', chatId: 'oc_same' },
+      { store },
+    );
+    const resolvedB = router.resolve(
+      { channelType: 'feishu', botName: 'bot-b', chatId: 'oc_same' },
+      { store },
+    );
+
+    assert.equal(resolvedA.id, botABinding.id);
+    assert.equal(resolvedB.id, botBBinding.id);
+    assert.notEqual(resolvedA.codepilotSessionId, resolvedB.codepilotSessionId);
+  });
+
+  it('createBinding() uses workingDirectory from RouterOpts', () => {
+    const store = createStore('/tmp/default');
+
+    const binding = router.createBinding(
+      { channelType: 'feishu', botName: 'bot-c', chatId: 'oc_2' },
+      { store, workingDirectory: '/tmp/from-opts' },
+    );
+
+    assert.equal(binding.botName, 'bot-c');
+    assert.equal(binding.workingDirectory, '/tmp/from-opts');
+    assert.equal(store.sessions.get(binding.codepilotSessionId)?.working_directory, '/tmp/from-opts');
+  });
+});

--- a/src/__tests__/unit/store-multi-bot.test.ts
+++ b/src/__tests__/unit/store-multi-bot.test.ts
@@ -1,0 +1,82 @@
+import { describe, test, beforeEach, afterEach } from 'node:test';
+import assert from 'node:assert/strict';
+import fs from 'node:fs';
+import path from 'node:path';
+import os from 'node:os';
+import { JsonFileStore } from '../../store';
+
+describe('JsonFileStore multi-bot', () => {
+  let tmpDir: string;
+
+  beforeEach(() => {
+    tmpDir = fs.mkdtempSync(path.join(os.tmpdir(), 'cti-test-'));
+  });
+
+  afterEach(() => {
+    fs.rmSync(tmpDir, { recursive: true, force: true });
+  });
+
+  test('constructor with dataDir uses custom path', () => {
+    const customDir = path.join(tmpDir, 'bot-jason');
+    fs.mkdirSync(customDir, { recursive: true });
+    const settings = new Map<string, string>();
+    const store = new JsonFileStore(settings, customDir);
+
+    store.upsertChannelBinding({
+      channelType: 'feishu',
+      chatId: 'oc_test',
+      codepilotSessionId: 'sess_1',
+      workingDirectory: '/tmp/test',
+      model: 'claude-3',
+      botName: 'jason',
+    });
+
+    const binding = store.getChannelBinding('feishu', 'oc_test', 'jason');
+    assert.ok(binding);
+    assert.equal(binding.botName, 'jason');
+    assert.ok(fs.existsSync(path.join(customDir, 'bindings.json')));
+  });
+
+  test('binding key includes botName when provided', () => {
+    const customDir = path.join(tmpDir, 'bot-a');
+    fs.mkdirSync(customDir, { recursive: true });
+    const store = new JsonFileStore(new Map(), customDir);
+
+    store.upsertChannelBinding({
+      channelType: 'feishu',
+      chatId: 'oc_same',
+      codepilotSessionId: 'sess_a',
+      workingDirectory: '/tmp/a',
+      model: 'claude-3',
+      botName: 'botA',
+    });
+
+    const miss = store.getChannelBinding('feishu', 'oc_same');
+    const hit = store.getChannelBinding('feishu', 'oc_same', 'botA');
+    assert.equal(miss, null);
+    assert.ok(hit);
+    assert.equal(hit.codepilotSessionId, 'sess_a');
+  });
+
+  test('two stores with different dataDirs are isolated', () => {
+    const dirA = path.join(tmpDir, 'bot-a');
+    const dirB = path.join(tmpDir, 'bot-b');
+    fs.mkdirSync(dirA, { recursive: true });
+    fs.mkdirSync(dirB, { recursive: true });
+
+    const storeA = new JsonFileStore(new Map(), dirA);
+    const storeB = new JsonFileStore(new Map(), dirB);
+
+    storeA.upsertChannelBinding({
+      channelType: 'feishu',
+      chatId: 'oc_1',
+      codepilotSessionId: 'sess_a',
+      workingDirectory: '/a',
+      model: 'claude-3',
+      botName: 'a',
+    });
+
+    const fromB = storeB.getChannelBinding('feishu', 'oc_1', 'a');
+    assert.equal(fromB, null);
+  });
+});

--- a/src/__tests__/unit/store-propagation.test.ts
+++ b/src/__tests__/unit/store-propagation.test.ts
@@ -1,0 +1,178 @@
+/**
+ * Unit tests for explicit BridgeStore propagation across engine -> broker -> delivery.
+ */
+
+import { describe, it, beforeEach } from 'node:test';
+import assert from 'node:assert/strict';
+import { initBridgeContext } from '../../lib/bridge/context';
+import { processMessage } from '../../lib/bridge/conversation-engine';
+import { forwardPermissionRequest } from '../../lib/bridge/permission-broker';
+import type { BaseChannelAdapter } from '../../lib/bridge/channel-adapter';
+import type { BridgeStore, LLMProvider, PermissionGateway } from '../../lib/bridge/host';
+import type { ChannelAddress, OutboundMessage, SendResult } from '../../lib/bridge/types';
+
+function streamFromEvents(events: Array<{ type: string; data: unknown }>): ReadableStream<string> {
+  return new ReadableStream({
+    start(controller) {
+      for (const event of events) {
+        controller.enqueue(`data: ${JSON.stringify({
+          type: event.type,
+          data: typeof event.data === 'string' ? event.data : JSON.stringify(event.data),
+        })}\n`);
+      }
+      controller.close();
+    },
+  });
+}
+
+function createMockStore(name: string) {
+  const messages: Array<{ sessionId: string; role: string; content: string }> = [];
+  const auditLogs: unknown[] = [];
+  const outboundRefs: unknown[] = [];
+  const permissionLinks: unknown[] = [];
+  const dedupKeys = new Set<string>();
+
+  return {
+    name,
+    messages,
+    auditLogs,
+    outboundRefs,
+    permissionLinks,
+    dedupKeys,
+    getSetting: () => null,
+    getChannelBinding: () => null,
+    upsertChannelBinding: () => ({} as any),
+    updateChannelBinding: () => {},
+    listChannelBindings: () => [],
+    getSession: (id: string) => ({ id, working_directory: '', model: '' }),
+    createSession: () => ({ id: 'session-created', working_directory: '', model: '' }),
+    updateSessionProviderId: () => {},
+    addMessage: (sessionId: string, role: string, content: string) => {
+      messages.push({ sessionId, role, content });
+    },
+    getMessages: () => ({ messages: messages.map(m => ({ role: m.role, content: m.content })) }),
+    acquireSessionLock: () => true,
+    renewSessionLock: () => {},
+    releaseSessionLock: () => {},
+    setSessionRuntimeStatus: () => {},
+    updateSdkSessionId: () => {},
+    updateSessionModel: () => {},
+    syncSdkTasks: () => {},
+    getProvider: () => undefined,
+    getDefaultProviderId: () => null,
+    insertAuditLog: (entry: unknown) => { auditLogs.push(entry); },
+    checkDedup: (key: string) => dedupKeys.has(key),
+    insertDedup: (key: string) => { dedupKeys.add(key); },
+    cleanupExpiredDedup: () => {},
+    insertOutboundRef: (ref: unknown) => { outboundRefs.push(ref); },
+    insertPermissionLink: (link: unknown) => { permissionLinks.push(link); },
+    getPermissionLink: () => null,
+    markPermissionLinkResolved: () => false,
+    listPendingPermissionLinksByChat: () => [],
+    getChannelOffset: () => '0',
+    setChannelOffset: () => {},
+  };
+}
+
+function createMockAdapter(): BaseChannelAdapter {
+  return {
+    channelType: 'telegram',
+    start: async () => {},
+    stop: async () => {},
+    isRunning: () => true,
+    consumeOne: async () => null,
+    send: async (_msg: OutboundMessage): Promise<SendResult> => ({ ok: true, messageId: 'platform-msg-1' }),
+    validateConfig: () => null,
+    isAuthorized: () => true,
+  } as unknown as BaseChannelAdapter;
+}
+
+describe('store propagation', () => {
+  let globalStore: ReturnType<typeof createMockStore>;
+  let injectedStore: ReturnType<typeof createMockStore>;
+
+  beforeEach(() => {
+    globalStore = createMockStore('global');
+    injectedStore = createMockStore('injected');
+
+    const llm: LLMProvider = {
+      streamChat: () => streamFromEvents([
+        {
+          type: 'permission_request',
+          data: {
+            permissionRequestId: 'perm-store-flow',
+            toolName: 'Bash',
+            toolInput: { command: 'pwd' },
+            suggestions: [{ type: 'allow', toolName: 'Bash' }],
+          },
+        },
+        { type: 'text', data: 'done' },
+      ]),
+    };
+
+    const permissions: PermissionGateway = {
+      resolvePendingPermission: () => false,
+    };
+
+    delete (globalThis as Record<string, unknown>)['__bridge_context__'];
+    initBridgeContext({
+      store: globalStore as unknown as BridgeStore,
+      llm,
+      permissions,
+      lifecycle: {},
+    });
+  });
+
+  it('passes processMessage opts.store through permission broker delivery', async () => {
+    const adapter = createMockAdapter();
+    const address: ChannelAddress = { channelType: 'telegram', chatId: 'chat-1' };
+    const permissionForwards: Promise<void>[] = [];
+    let callbackStore: BridgeStore | undefined;
+
+    const result = await processMessage(
+      {
+        id: 'binding-1',
+        channelType: 'telegram',
+        chatId: 'chat-1',
+        codepilotSessionId: 'session-1',
+        workingDirectory: '',
+        model: '',
+        mode: 'code',
+      } as any,
+      'hello',
+      (perm, opts) => {
+        callbackStore = opts?.store;
+        const forward = forwardPermissionRequest(
+          adapter,
+          address,
+          perm.permissionRequestId,
+          perm.toolName,
+          perm.toolInput,
+          'session-1',
+          perm.suggestions,
+          undefined,
+          opts?.store,
+        );
+        permissionForwards.push(forward);
+        return forward;
+      },
+      undefined,
+      undefined,
+      undefined,
+      undefined,
+      undefined,
+      { store: injectedStore as unknown as BridgeStore },
+    );
+
+    await Promise.all(permissionForwards);
+
+    assert.equal(result.responseText, 'done');
+    assert.equal(callbackStore, injectedStore);
+    assert.equal(injectedStore.permissionLinks.length, 1);
+    assert.equal(injectedStore.outboundRefs.length, 1);
+    assert.equal(injectedStore.auditLogs.length, 1);
+    assert.equal(globalStore.permissionLinks.length, 0);
+    assert.equal(globalStore.outboundRefs.length, 0);
+    assert.equal(globalStore.auditLogs.length, 0);
+  });
+});

--- a/src/adapters/weixin-adapter.ts
+++ b/src/adapters/weixin-adapter.ts
@@ -1,0 +1,477 @@
+import type {
+  ChannelType,
+  FileAttachment,
+  InboundMessage,
+  OutboundMessage,
+  SendResult,
+} from 'claude-to-im/src/lib/bridge/types.js';
+import { BaseChannelAdapter, registerAdapterFactory } from 'claude-to-im/src/lib/bridge/channel-adapter.js';
+import { getBridgeContext } from 'claude-to-im/src/lib/bridge/context.js';
+import {
+  getWeixinAccount,
+  getWeixinContextToken,
+  listWeixinAccounts,
+  upsertWeixinContextToken,
+} from '../weixin-store.js';
+import { getConfig, getUpdates, sendTextMessage, sendTyping } from './weixin/weixin-api.js';
+import { decodeWeixinChatId, encodeWeixinChatId } from './weixin/weixin-ids.js';
+import { downloadMediaFromItem } from './weixin/weixin-media.js';
+import { clearAllPauses, isPaused, setPaused } from './weixin/weixin-session-guard.js';
+import type {
+  GetUpdatesResponse,
+  WeixinCredentials,
+  WeixinMessage,
+} from './weixin/weixin-types.js';
+import {
+  DEFAULT_BASE_URL,
+  DEFAULT_CDN_BASE_URL,
+  ERRCODE_SESSION_EXPIRED,
+  MessageItemType,
+  TypingStatus,
+} from './weixin/weixin-types.js';
+
+const DEDUP_MAX = 500;
+const BACKOFF_BASE_MS = 2_000;
+const BACKOFF_MAX_MS = 30_000;
+
+export class WeixinAdapter extends BaseChannelAdapter {
+  readonly channelType: ChannelType = 'weixin';
+
+  private _running = false;
+  private queue: InboundMessage[] = [];
+  private waiters: Array<(msg: InboundMessage | null) => void> = [];
+  private pollAborts = new Map<string, AbortController>();
+  private seenMessageIds = new Map<string, Set<string>>();
+  private consecutiveFailures = new Map<string, number>();
+  private typingTickets = new Map<string, string>();
+  private pendingCursors = new Map<number, {
+    offsetKey: string;
+    cursor: string;
+    remaining: number;
+    sealed: boolean;
+  }>();
+  private nextBatchId = 1;
+
+  async start(): Promise<void> {
+    if (this._running) return;
+    this._running = true;
+    clearAllPauses();
+
+    const linkedAccounts = listWeixinAccounts().filter((account) => account.enabled && account.token);
+    if (linkedAccounts.length === 0) {
+      console.log('[weixin-adapter] No linked WeChat account is enabled, adapter started but idle');
+    }
+
+    for (const account of linkedAccounts) {
+      this.startAccountWorker(account.accountId, this.accountToCreds(account));
+    }
+
+    if (linkedAccounts.length > 0) {
+      console.log(`[weixin-adapter] Started in single-account mode with ${linkedAccounts[0].accountId}`);
+    }
+  }
+
+  async stop(): Promise<void> {
+    if (!this._running) return;
+    this._running = false;
+
+    for (const controller of this.pollAborts.values()) {
+      controller.abort();
+    }
+
+    this.pollAborts.clear();
+    this.pendingCursors.clear();
+    this.seenMessageIds.clear();
+    this.consecutiveFailures.clear();
+    this.typingTickets.clear();
+    this.queue = [];
+
+    for (const waiter of this.waiters) {
+      waiter(null);
+    }
+    this.waiters = [];
+
+    console.log('[weixin-adapter] Stopped');
+  }
+
+  isRunning(): boolean {
+    return this._running;
+  }
+
+  async consumeOne(): Promise<InboundMessage | null> {
+    if (this.queue.length > 0) {
+      return this.queue.shift()!;
+    }
+    if (!this._running) {
+      return null;
+    }
+    return new Promise<InboundMessage | null>((resolve) => {
+      this.waiters.push(resolve);
+    });
+  }
+
+  async send(message: OutboundMessage): Promise<SendResult> {
+    try {
+      const decoded = decodeWeixinChatId(message.address.chatId);
+      if (!decoded) {
+        return { ok: false, error: 'Invalid WeChat chatId format' };
+      }
+
+      const { accountId, peerUserId } = decoded;
+      const account = getWeixinAccount(accountId);
+      if (!account) {
+        return { ok: false, error: `Linked WeChat account ${accountId} not found` };
+      }
+
+      const contextToken = getWeixinContextToken(accountId, peerUserId);
+      if (!contextToken) {
+        return { ok: false, error: `No context token for peer ${peerUserId} on account ${accountId}` };
+      }
+
+      const content = stripFormatting(message.text, message.parseMode);
+      const { clientId } = await sendTextMessage(
+        this.accountToCreds(account),
+        peerUserId,
+        content,
+        contextToken,
+      );
+
+      return { ok: true, messageId: clientId };
+    } catch (err) {
+      return { ok: false, error: err instanceof Error ? err.message : String(err) };
+    }
+  }
+
+  validateConfig(): string | null {
+    const linkedAccounts = listWeixinAccounts().filter((account) => account.enabled && account.token);
+    if (linkedAccounts.length === 0) {
+      return 'No linked WeChat account. Run the WeChat QR login helper first.';
+    }
+    return null;
+  }
+
+  isAuthorized(_userId: string, _chatId: string): boolean {
+    return true;
+  }
+
+  acknowledgeUpdate(updateId: number): void {
+    const batch = this.pendingCursors.get(updateId);
+    if (!batch) return;
+    batch.remaining = Math.max(0, batch.remaining - 1);
+    this.maybeCommitPendingCursor(updateId);
+  }
+
+  onMessageStart(chatId: string): void {
+    this.sendTypingIndicator(chatId, TypingStatus.TYPING).catch(() => {});
+  }
+
+  onMessageEnd(chatId: string): void {
+    this.sendTypingIndicator(chatId, TypingStatus.CANCEL).catch(() => {});
+  }
+
+  private enqueue(message: InboundMessage): void {
+    if (this.waiters.length > 0) {
+      const waiter = this.waiters.shift()!;
+      waiter(message);
+      return;
+    }
+    this.queue.push(message);
+  }
+
+  private startAccountWorker(accountId: string, creds: WeixinCredentials): void {
+    const controller = new AbortController();
+    this.pollAborts.set(accountId, controller);
+    this.seenMessageIds.set(accountId, new Set());
+    this.consecutiveFailures.set(accountId, 0);
+    void this.runPollLoop(accountId, creds, controller.signal);
+  }
+
+  private async runPollLoop(accountId: string, creds: WeixinCredentials, signal: AbortSignal): Promise<void> {
+    console.log(`[weixin-adapter] Poll loop started for account ${accountId}`);
+
+    while (this._running && !signal.aborted) {
+      if (isPaused(accountId)) {
+        await this.sleep(10_000, signal);
+        continue;
+      }
+
+      try {
+        const { store } = getBridgeContext();
+        const offsetKey = `weixin:${accountId}`;
+        const rawOffset = store.getChannelOffset(offsetKey);
+        const cursor = rawOffset === '0' ? '' : rawOffset;
+        const response: GetUpdatesResponse = await getUpdates(creds, cursor);
+
+        if (response.errcode === ERRCODE_SESSION_EXPIRED) {
+          setPaused(accountId, 'Session expired (errcode -14)');
+          console.warn(`[weixin-adapter] Account ${accountId} session expired, pausing`);
+          continue;
+        }
+        if (response.errcode && response.errcode !== 0) {
+          throw new Error(`API error: ${response.errcode} ${response.errmsg || ''}`.trim());
+        }
+
+        let batchId: number | undefined;
+        let batchCompleted = false;
+
+        if (response.msgs && response.msgs.length > 0 && response.get_updates_buf) {
+          batchId = this.nextBatchId++;
+          this.pendingCursors.set(batchId, {
+            offsetKey,
+            cursor: response.get_updates_buf,
+            remaining: 0,
+            sealed: false,
+          });
+
+          for (const message of response.msgs) {
+            await this.processMessage(accountId, message, batchId);
+          }
+          batchCompleted = true;
+        } else if (response.msgs && response.msgs.length > 0) {
+          for (const message of response.msgs) {
+            await this.processMessage(accountId, message);
+          }
+        }
+
+        if (batchId !== undefined && response.get_updates_buf) {
+          const batch = this.pendingCursors.get(batchId);
+          if (batchCompleted && batch) {
+            batch.sealed = true;
+            this.maybeCommitPendingCursor(batchId);
+          } else if (!batchCompleted) {
+            this.pendingCursors.delete(batchId);
+          }
+        }
+
+        this.consecutiveFailures.set(accountId, 0);
+      } catch (err) {
+        if (signal.aborted) break;
+
+        const failures = (this.consecutiveFailures.get(accountId) || 0) + 1;
+        this.consecutiveFailures.set(accountId, failures);
+        const backoff = Math.min(BACKOFF_BASE_MS * Math.pow(2, failures - 1), BACKOFF_MAX_MS);
+
+        console.error(
+          `[weixin-adapter] Poll error for ${accountId} (failure ${failures}):`,
+          err instanceof Error ? err.message : err,
+        );
+        await this.sleep(backoff, signal);
+      }
+    }
+
+    console.log(`[weixin-adapter] Poll loop ended for account ${accountId}`);
+  }
+
+  private async processMessage(accountId: string, message: WeixinMessage, batchId?: number): Promise<void> {
+    if (!message.from_user_id) return;
+
+    const messageKey = message.message_id || `seq_${message.seq}`;
+    const seenIds = this.seenMessageIds.get(accountId);
+    if (seenIds?.has(messageKey)) {
+      return;
+    }
+
+    seenIds?.add(messageKey);
+    if (seenIds && seenIds.size > DEDUP_MAX) {
+      const overflow = Array.from(seenIds).slice(0, seenIds.size - DEDUP_MAX);
+      for (const staleKey of overflow) {
+        seenIds.delete(staleKey);
+      }
+    }
+
+    if (message.context_token) {
+      upsertWeixinContextToken(accountId, message.from_user_id, message.context_token);
+    }
+
+    let text = '';
+    const attachments: FileAttachment[] = [];
+    let failedCount = 0;
+    let missingVoiceTranscriptCount = 0;
+    const mediaEnabled = getBridgeContext().store.getSetting('bridge_weixin_media_enabled') === 'true';
+    const account = mediaEnabled ? getWeixinAccount(accountId) : undefined;
+    const creds = account ? this.accountToCreds(account) : undefined;
+
+    for (const item of message.item_list || []) {
+      if (item.type === MessageItemType.TEXT && item.text_item?.text) {
+        text += item.text_item.text;
+        continue;
+      }
+
+      if (item.type === MessageItemType.VOICE) {
+        const transcript = item.voice_item?.text?.trim();
+        if (transcript) {
+          text = text.trim() ? `${text}\n${transcript}` : transcript;
+        } else {
+          missingVoiceTranscriptCount++;
+        }
+        continue;
+      }
+
+      if (!mediaEnabled || !creds) {
+        continue;
+      }
+
+      try {
+        const attachment = await downloadMediaFromItem(item, creds.cdnBaseUrl);
+        if (attachment) {
+          attachments.push(attachment);
+        }
+      } catch (err) {
+        failedCount++;
+        console.warn(
+          `[weixin-adapter] Failed to download media for ${accountId}:`,
+          err instanceof Error ? err.message : err,
+        );
+      }
+    }
+
+    if (message.ref_message) {
+      const quoted: string[] = [];
+      if (message.ref_message.title) quoted.push(message.ref_message.title);
+      if (message.ref_message.content) quoted.push(message.ref_message.content);
+      if (quoted.length > 0) {
+        text = `[引用: ${quoted.join(' | ')}]\n${text}`;
+      }
+    }
+
+    if (failedCount > 0) {
+      const failureNote = `[${failedCount} attachment(s) failed to download]`;
+      text = text.trim() ? `${text}\n${failureNote}` : (attachments.length > 0 ? failureNote : text);
+    }
+
+    const chatId = encodeWeixinChatId(accountId, message.from_user_id);
+    const inbound: InboundMessage = {
+      messageId: message.message_id || `weixin_${accountId}_${message.seq || Date.now()}`,
+      address: {
+        channelType: 'weixin',
+        chatId,
+        userId: message.from_user_id,
+        displayName: message.from_user_id.slice(0, 12),
+      },
+      text: text.trim(),
+      timestamp: message.create_time ? message.create_time * 1000 : Date.now(),
+      raw: failedCount > 0 && attachments.length === 0 && !text.trim()
+        ? {
+            accountId,
+            originalMessage: message,
+            attachmentDownloadFailed: true,
+            failedCount,
+            failedLabel: 'attachment(s)',
+          }
+        : missingVoiceTranscriptCount > 0 && attachments.length === 0 && !text.trim()
+          ? {
+              accountId,
+              originalMessage: message,
+              userVisibleError: 'WeChat did not provide speech-to-text for this voice message. Please enable WeChat voice transcription and send it again.',
+            }
+          : { accountId, originalMessage: message },
+      updateId: batchId,
+      attachments: attachments.length > 0 ? attachments : undefined,
+    };
+
+    if (!inbound.text && attachments.length === 0 && failedCount === 0 && missingVoiceTranscriptCount === 0) {
+      return;
+    }
+
+    if (batchId !== undefined) {
+      const batch = this.pendingCursors.get(batchId);
+      if (batch) batch.remaining++;
+    }
+    this.enqueue(inbound);
+
+    const summary = attachments.length > 0
+      ? `[${attachments.length} attachment(s)] ${inbound.text.slice(0, 150)}`
+      : missingVoiceTranscriptCount > 0 && !inbound.text
+        ? '[voice transcription unavailable]'
+      : failedCount > 0 && !inbound.text
+        ? `[${failedCount} attachment(s) failed]`
+        : inbound.text.slice(0, 200);
+    getBridgeContext().store.insertAuditLog({
+      channelType: 'weixin',
+      chatId,
+      direction: 'inbound',
+      messageId: inbound.messageId,
+      summary,
+    });
+  }
+
+  private async sendTypingIndicator(chatId: string, status: number): Promise<void> {
+    const decoded = decodeWeixinChatId(chatId);
+    if (!decoded) return;
+
+    const { accountId, peerUserId } = decoded;
+    const account = getWeixinAccount(accountId);
+    if (!account) return;
+
+    const contextToken = getWeixinContextToken(accountId, peerUserId);
+    if (!contextToken) return;
+
+    const creds = this.accountToCreds(account);
+    const ticketKey = `${accountId}:${peerUserId}`;
+    let typingTicket = this.typingTickets.get(ticketKey);
+    if (!typingTicket) {
+      const config = await getConfig(creds, peerUserId, contextToken);
+      if (!config.typing_ticket) return;
+      typingTicket = config.typing_ticket;
+      this.typingTickets.set(ticketKey, typingTicket);
+    }
+
+    await sendTyping(creds, peerUserId, typingTicket, status);
+  }
+
+  private accountToCreds(account: {
+    accountId: string;
+    token: string;
+    baseUrl?: string;
+    cdnBaseUrl?: string;
+  }): WeixinCredentials {
+    return {
+      botToken: account.token,
+      ilinkBotId: account.accountId,
+      baseUrl: account.baseUrl || DEFAULT_BASE_URL,
+      cdnBaseUrl: account.cdnBaseUrl || DEFAULT_CDN_BASE_URL,
+    };
+  }
+
+  private sleep(ms: number, signal?: AbortSignal): Promise<void> {
+    return new Promise((resolve) => {
+      const timer = setTimeout(resolve, ms);
+      signal?.addEventListener(
+        'abort',
+        () => {
+          clearTimeout(timer);
+          resolve();
+        },
+        { once: true },
+      );
+    });
+  }
+
+  private maybeCommitPendingCursor(updateId: number): void {
+    const batch = this.pendingCursors.get(updateId);
+    if (!batch || !batch.sealed || batch.remaining > 0) {
+      return;
+    }
+    getBridgeContext().store.setChannelOffset(batch.offsetKey, batch.cursor);
+    this.pendingCursors.delete(updateId);
+  }
+}
+
+function stripFormatting(text: string, parseMode?: 'HTML' | 'Markdown' | 'plain'): string {
+  if (parseMode === 'HTML') {
+    return text.replace(/<[^>]+>/g, '');
+  }
+  if (parseMode === 'Markdown') {
+    return text
+      .replace(/\*\*(.*?)\*\*/g, '$1')
+      .replace(/__(.*?)__/g, '$1')
+      .replace(/\*(.*?)\*/g, '$1')
+      .replace(/_(.*?)_/g, '$1')
+      .replace(/`{3}[\s\S]*?`{3}/g, (match) => match.replace(/`{3}\w*\n?/g, '').replace(/`{3}/g, ''))
+      .replace(/`([^`]+)`/g, '$1')
+      .replace(/\[([^\]]+)\]\([^)]+\)/g, '$1');
+  }
+  return text;
+}
+
+registerAdapterFactory('weixin', () => new WeixinAdapter());

--- a/src/adapters/weixin/weixin-api.ts
+++ b/src/adapters/weixin/weixin-api.ts
@@ -1,0 +1,209 @@
+import crypto from 'node:crypto';
+import type {
+  GetConfigResponse,
+  GetUpdatesResponse,
+  MessageItem,
+  QrCodeStartResponse,
+  QrCodeStatusResponse,
+  WeixinCredentials,
+} from './weixin-types.js';
+import {
+  DEFAULT_BASE_URL,
+  MessageItemType,
+} from './weixin-types.js';
+
+const CHANNEL_VERSION = 'claude-to-im-skill-weixin/1.0';
+const LONG_POLL_TIMEOUT_MS = 35_000;
+const API_TIMEOUT_MS = 15_000;
+const CONFIG_TIMEOUT_MS = 10_000;
+
+function generateWechatUin(): string {
+  return crypto.randomBytes(4).toString('base64');
+}
+
+function normalizeBaseUrl(baseUrl?: string): string {
+  return (baseUrl || DEFAULT_BASE_URL).replace(/\/+$/, '');
+}
+
+function buildHeaders(creds: WeixinCredentials): Record<string, string> {
+  return {
+    'Content-Type': 'application/json',
+    'AuthorizationType': 'ilink_bot_token',
+    Authorization: `Bearer ${creds.botToken}`,
+    'X-WECHAT-UIN': generateWechatUin(),
+  };
+}
+
+async function parseJsonResponse<T>(res: Response, label: string): Promise<T> {
+  const rawText = await res.text();
+  if (!rawText.trim()) {
+    return {} as T;
+  }
+  try {
+    return JSON.parse(rawText) as T;
+  } catch (err) {
+    throw new Error(
+      `WeChat API returned non-JSON body for ${label}: ${err instanceof Error ? err.message : String(err)}`,
+    );
+  }
+}
+
+async function weixinRequest<T>(
+  creds: WeixinCredentials,
+  endpoint: string,
+  body: unknown,
+  timeoutMs: number = API_TIMEOUT_MS,
+): Promise<T> {
+  const baseUrl = normalizeBaseUrl(creds.baseUrl);
+  const url = `${baseUrl}/ilink/bot/${endpoint}`;
+
+  const res = await fetch(url, {
+    method: 'POST',
+    headers: buildHeaders(creds),
+    body: JSON.stringify(body),
+    signal: AbortSignal.timeout(timeoutMs),
+  });
+
+  if (!res.ok) {
+    throw new Error(`WeChat API error: ${res.status} ${res.statusText}`);
+  }
+
+  return parseJsonResponse<T>(res, endpoint);
+}
+
+export async function getUpdates(
+  creds: WeixinCredentials,
+  getUpdatesBuf: string,
+  timeoutMs: number = LONG_POLL_TIMEOUT_MS,
+): Promise<GetUpdatesResponse> {
+  try {
+    return await weixinRequest<GetUpdatesResponse>(
+      creds,
+      'getupdates',
+      {
+        get_updates_buf: getUpdatesBuf ?? '',
+        base_info: { channel_version: CHANNEL_VERSION },
+      },
+      timeoutMs + 5_000,
+    );
+  } catch (err) {
+    if (err instanceof Error && err.name === 'TimeoutError') {
+      return { msgs: [], get_updates_buf: getUpdatesBuf };
+    }
+    throw err;
+  }
+}
+
+function generateClientId(): string {
+  return `cti-weixin-${Date.now()}-${crypto.randomBytes(4).toString('hex')}`;
+}
+
+async function sendMessage(
+  creds: WeixinCredentials,
+  toUserId: string,
+  items: MessageItem[],
+  contextToken: string,
+): Promise<{ clientId: string }> {
+  const clientId = generateClientId();
+
+  await weixinRequest<Record<string, unknown>>(
+    creds,
+    'sendmessage',
+    {
+      msg: {
+        from_user_id: '',
+        to_user_id: toUserId,
+        client_id: clientId,
+        message_type: 2,
+        message_state: 2,
+        item_list: items.length > 0 ? items : undefined,
+        context_token: contextToken || undefined,
+      },
+      base_info: { channel_version: CHANNEL_VERSION },
+    },
+  );
+
+  return { clientId };
+}
+
+export async function sendTextMessage(
+  creds: WeixinCredentials,
+  toUserId: string,
+  text: string,
+  contextToken: string,
+): Promise<{ clientId: string }> {
+  return sendMessage(
+    creds,
+    toUserId,
+    [{ type: MessageItemType.TEXT, text_item: { text } }],
+    contextToken,
+  );
+}
+
+export async function getConfig(
+  creds: WeixinCredentials,
+  ilinkUserId: string,
+  contextToken: string,
+): Promise<GetConfigResponse> {
+  return weixinRequest<GetConfigResponse>(
+    creds,
+    'getconfig',
+    {
+      ilink_user_id: ilinkUserId,
+      context_token: contextToken,
+      base_info: { channel_version: CHANNEL_VERSION },
+    },
+    CONFIG_TIMEOUT_MS,
+  );
+}
+
+export async function sendTyping(
+  creds: WeixinCredentials,
+  ilinkUserId: string,
+  typingTicket: string,
+  status: number,
+): Promise<void> {
+  try {
+    await weixinRequest<Record<string, unknown>>(
+      creds,
+      'sendtyping',
+      {
+        ilink_user_id: ilinkUserId,
+        typing_ticket: typingTicket,
+        status,
+        base_info: { channel_version: CHANNEL_VERSION },
+      },
+      CONFIG_TIMEOUT_MS,
+    );
+  } catch {
+    // Typing is best-effort only.
+  }
+}
+
+export async function startLoginQr(baseUrl?: string): Promise<QrCodeStartResponse> {
+  const url = `${normalizeBaseUrl(baseUrl)}/ilink/bot/get_bot_qrcode?bot_type=3`;
+  const res = await fetch(url, {
+    method: 'GET',
+    signal: AbortSignal.timeout(API_TIMEOUT_MS),
+  });
+
+  if (!res.ok) {
+    throw new Error(`QR login start failed: ${res.status}`);
+  }
+
+  return parseJsonResponse<QrCodeStartResponse>(res, 'get_bot_qrcode');
+}
+
+export async function pollLoginQrStatus(qrcode: string, baseUrl?: string): Promise<QrCodeStatusResponse> {
+  const url = `${normalizeBaseUrl(baseUrl)}/ilink/bot/get_qrcode_status?qrcode=${encodeURIComponent(qrcode)}`;
+  const res = await fetch(url, {
+    method: 'GET',
+    signal: AbortSignal.timeout(LONG_POLL_TIMEOUT_MS + 5_000),
+  });
+
+  if (!res.ok) {
+    throw new Error(`QR login poll failed: ${res.status}`);
+  }
+
+  return parseJsonResponse<QrCodeStatusResponse>(res, 'get_qrcode_status');
+}

--- a/src/adapters/weixin/weixin-ids.ts
+++ b/src/adapters/weixin/weixin-ids.ts
@@ -1,0 +1,19 @@
+const WEIXIN_PREFIX = 'weixin::';
+const SEPARATOR = '::';
+
+export function encodeWeixinChatId(accountId: string, peerUserId: string): string {
+  return `${WEIXIN_PREFIX}${accountId}${SEPARATOR}${peerUserId}`;
+}
+
+export function decodeWeixinChatId(chatId: string): { accountId: string; peerUserId: string } | null {
+  if (!chatId.startsWith(WEIXIN_PREFIX)) return null;
+  const rest = chatId.slice(WEIXIN_PREFIX.length);
+  const separatorIndex = rest.indexOf(SEPARATOR);
+  if (separatorIndex < 0) return null;
+
+  const accountId = rest.slice(0, separatorIndex);
+  const peerUserId = rest.slice(separatorIndex + SEPARATOR.length);
+  if (!accountId || !peerUserId) return null;
+
+  return { accountId, peerUserId };
+}

--- a/src/adapters/weixin/weixin-media.ts
+++ b/src/adapters/weixin/weixin-media.ts
@@ -1,0 +1,148 @@
+import crypto from 'node:crypto';
+import type { FileAttachment } from 'claude-to-im/src/lib/bridge/types.js';
+import type { CDNMedia, MessageItem } from './weixin-types.js';
+import { MessageItemType } from './weixin-types.js';
+
+const MAX_MEDIA_SIZE = 100 * 1024 * 1024;
+
+export function encryptMedia(data: Buffer, key: Buffer): Buffer {
+  const cipher = crypto.createCipheriv('aes-128-ecb', key, null);
+  return Buffer.concat([cipher.update(data), cipher.final()]);
+}
+
+export function decryptMedia(data: Buffer, key: Buffer): Buffer {
+  const decipher = crypto.createDecipheriv('aes-128-ecb', key, null);
+  return Buffer.concat([decipher.update(data), decipher.final()]);
+}
+
+function parseBase64EncodedAesKey(aesKeyBase64: string): Buffer {
+  const decoded = Buffer.from(aesKeyBase64, 'base64');
+  if (decoded.length === 16) {
+    return decoded;
+  }
+
+  const ascii = decoded.toString('ascii');
+  if (decoded.length === 32 && /^[0-9a-fA-F]{32}$/.test(ascii)) {
+    return Buffer.from(ascii, 'hex');
+  }
+
+  throw new Error(`Invalid AES key length: expected 16 raw bytes or 32-char hex, got ${decoded.length} bytes`);
+}
+
+function parseAesKey(item: { aeskey?: string; media?: CDNMedia }): Buffer | null {
+  if (item.aeskey && item.aeskey.length === 32) {
+    return Buffer.from(item.aeskey, 'hex');
+  }
+  if (item.media?.aes_key) {
+    return parseBase64EncodedAesKey(item.media.aes_key);
+  }
+  return null;
+}
+
+function guessMimeType(filename: string): string {
+  const ext = filename.split('.').pop()?.toLowerCase();
+  if (!ext) return 'application/octet-stream';
+
+  const mimeMap: Record<string, string> = {
+    jpg: 'image/jpeg',
+    jpeg: 'image/jpeg',
+    png: 'image/png',
+    gif: 'image/gif',
+    webp: 'image/webp',
+    pdf: 'application/pdf',
+    txt: 'text/plain',
+    zip: 'application/zip',
+    doc: 'application/msword',
+    docx: 'application/vnd.openxmlformats-officedocument.wordprocessingml.document',
+    xls: 'application/vnd.ms-excel',
+    xlsx: 'application/vnd.openxmlformats-officedocument.spreadsheetml.sheet',
+    mp4: 'video/mp4',
+    silk: 'audio/silk',
+  };
+  return mimeMap[ext] || 'application/octet-stream';
+}
+
+function buildCdnDownloadUrl(encryptParam: string, cdnBaseUrl: string): string {
+  const normalizedBaseUrl = cdnBaseUrl.replace(/\/+$/, '');
+  return `${normalizedBaseUrl}/download?encrypted_query_param=${encodeURIComponent(encryptParam)}`;
+}
+
+async function downloadAndDecryptMedia(cdnUrl: string, aesKey: Buffer, label: string): Promise<Buffer> {
+  const res = await fetch(cdnUrl, {
+    signal: AbortSignal.timeout(60_000),
+  });
+
+  if (!res.ok) {
+    throw new Error(`CDN download failed for ${label}: ${res.status}`);
+  }
+
+  const encrypted = Buffer.from(await res.arrayBuffer());
+  if (encrypted.length === 0) {
+    throw new Error(`Downloaded ${label} is empty`);
+  }
+  if (encrypted.length > MAX_MEDIA_SIZE) {
+    throw new Error(`Media too large: ${encrypted.length} bytes`);
+  }
+
+  return decryptMedia(encrypted, aesKey);
+}
+
+export async function downloadMediaFromItem(
+  item: MessageItem,
+  cdnBaseUrl: string,
+): Promise<FileAttachment | null> {
+  let encryptParam: string | undefined;
+  let aesKey: Buffer | null = null;
+  let filename = 'file.bin';
+  let mimeType = 'application/octet-stream';
+
+  switch (item.type) {
+    case MessageItemType.IMAGE:
+      if (item.image_item) {
+        encryptParam = item.image_item.media?.encrypt_query_param;
+        aesKey = parseAesKey(item.image_item);
+        filename = `image_${Date.now()}.jpg`;
+        mimeType = 'image/jpeg';
+      }
+      break;
+    case MessageItemType.VOICE:
+      if (item.voice_item) {
+        encryptParam = item.voice_item.media?.encrypt_query_param;
+        aesKey = parseAesKey(item.voice_item);
+        filename = `voice_${Date.now()}.silk`;
+        mimeType = 'audio/silk';
+      }
+      break;
+    case MessageItemType.FILE:
+      if (item.file_item) {
+        encryptParam = item.file_item.media?.encrypt_query_param;
+        aesKey = parseAesKey(item.file_item);
+        filename = item.file_item.file_name || `file_${Date.now()}`;
+        mimeType = guessMimeType(filename);
+      }
+      break;
+    case MessageItemType.VIDEO:
+      if (item.video_item) {
+        encryptParam = item.video_item.media?.encrypt_query_param;
+        aesKey = parseAesKey(item.video_item);
+        filename = `video_${Date.now()}.mp4`;
+        mimeType = 'video/mp4';
+      }
+      break;
+    default:
+      return null;
+  }
+
+  if (!encryptParam || !aesKey) {
+    return null;
+  }
+
+  const data = await downloadAndDecryptMedia(buildCdnDownloadUrl(encryptParam, cdnBaseUrl), aesKey, filename);
+  return {
+    id: crypto.randomUUID(),
+    name: filename,
+    type: mimeType,
+    size: data.length,
+    data: data.toString('base64'),
+  };
+}

--- a/src/adapters/weixin/weixin-session-guard.ts
+++ b/src/adapters/weixin/weixin-session-guard.ts
@@ -1,0 +1,33 @@
+const PAUSE_DURATION_MS = 60 * 60 * 1000;
+
+interface AccountPauseState {
+  pausedAt: number;
+  resumeAt: number;
+  reason: string;
+}
+
+const pauseStates = new Map<string, AccountPauseState>();
+
+export function isPaused(accountId: string): boolean {
+  const state = pauseStates.get(accountId);
+  if (!state) return false;
+  if (Date.now() >= state.resumeAt) {
+    pauseStates.delete(accountId);
+    return false;
+  }
+  return true;
+}
+
+export function setPaused(accountId: string, reason: string = 'Session expired'): void {
+  const pausedAt = Date.now();
+  pauseStates.set(accountId, {
+    pausedAt,
+    resumeAt: pausedAt + PAUSE_DURATION_MS,
+    reason,
+  });
+  console.log(`[weixin-session-guard] Account ${accountId} paused for 60 min: ${reason}`);
+}
+
+export function clearAllPauses(): void {
+  pauseStates.clear();
+}

--- a/src/adapters/weixin/weixin-types.ts
+++ b/src/adapters/weixin/weixin-types.ts
@@ -1,0 +1,111 @@
+export const MessageItemType = {
+  TEXT: 1,
+  IMAGE: 2,
+  VOICE: 3,
+  FILE: 4,
+  VIDEO: 5,
+} as const;
+
+export const TypingStatus = {
+  TYPING: 1,
+  CANCEL: 2,
+} as const;
+
+export interface CDNMedia {
+  encrypt_query_param?: string;
+  aes_key?: string;
+  encrypt_type?: number;
+}
+
+export interface TextItem {
+  text: string;
+}
+
+interface MediaItemBase {
+  media?: CDNMedia;
+  aeskey?: string;
+}
+
+export interface ImageItem extends MediaItemBase {
+  mid_size?: number;
+}
+
+export interface VoiceItem extends MediaItemBase {
+  voice_length_ms?: number;
+  text?: string;
+}
+
+export interface FileItem extends MediaItemBase {
+  file_name?: string;
+  file_size?: number;
+}
+
+export interface VideoItem extends MediaItemBase {
+  video_length_s?: number;
+}
+
+export interface MessageItem {
+  type: number;
+  text_item?: TextItem;
+  image_item?: ImageItem;
+  voice_item?: VoiceItem;
+  file_item?: FileItem;
+  video_item?: VideoItem;
+}
+
+export interface RefMessage {
+  title?: string;
+  content?: string;
+}
+
+export interface WeixinMessage {
+  seq?: number;
+  message_id?: string;
+  from_user_id: string;
+  item_list?: MessageItem[];
+  context_token?: string;
+  create_time?: number;
+  ref_message?: RefMessage;
+}
+
+export interface GetUpdatesResponse {
+  errcode?: number;
+  errmsg?: string;
+  msgs?: WeixinMessage[];
+  get_updates_buf?: string;
+  longpolling_timeout_ms?: number;
+}
+
+export interface GetConfigResponse {
+  errcode?: number;
+  errmsg?: string;
+  typing_ticket?: string;
+}
+
+export interface QrCodeStartResponse {
+  errcode?: number;
+  errmsg?: string;
+  qrcode?: string;
+  qrcode_img_content?: string;
+}
+
+export interface QrCodeStatusResponse {
+  errcode?: number;
+  errmsg?: string;
+  status?: 'wait' | 'scaned' | 'confirmed' | 'expired';
+  bot_token?: string;
+  ilink_bot_id?: string;
+  baseurl?: string;
+  ilink_user_id?: string;
+}
+
+export interface WeixinCredentials {
+  botToken: string;
+  ilinkBotId: string;
+  baseUrl: string;
+  cdnBaseUrl: string;
+}
+
+export const ERRCODE_SESSION_EXPIRED = -14;
+export const DEFAULT_BASE_URL = 'https://ilinkai.weixin.qq.com';
+export const DEFAULT_CDN_BASE_URL = 'https://novac2c.cdn.weixin.qq.com/c2c';

--- a/src/codex-provider.ts
+++ b/src/codex-provider.ts
@@ -1,0 +1,378 @@
+/**
+ * Codex Provider — LLMProvider implementation backed by @openai/codex-sdk.
+ *
+ * Maps Codex SDK thread events to the SSE stream format consumed by
+ * the bridge conversation engine, making Codex a drop-in alternative
+ * to the Claude Code SDK backend.
+ *
+ * Requires `@openai/codex-sdk` to be installed (optionalDependency).
+ * The provider lazily imports the SDK at first use and throws a clear
+ * error if it is not available.
+ */
+
+import fs from 'node:fs';
+import os from 'node:os';
+import path from 'node:path';
+
+import type { LLMProvider, StreamChatParams } from 'claude-to-im/src/lib/bridge/host.js';
+import type { PendingPermissions } from './permission-gateway.js';
+import { sseEvent } from './sse-utils.js';
+
+/** MIME → file extension for temp image files. */
+const MIME_EXT: Record<string, string> = {
+  'image/png': '.png',
+  'image/jpeg': '.jpg',
+  'image/jpg': '.jpg',
+  'image/gif': '.gif',
+  'image/webp': '.webp',
+};
+
+// All SDK types kept as `any` because @openai/codex-sdk is optional.
+// eslint-disable-next-line @typescript-eslint/no-explicit-any
+type CodexModule = any;
+// eslint-disable-next-line @typescript-eslint/no-explicit-any
+type CodexInstance = any;
+// eslint-disable-next-line @typescript-eslint/no-explicit-any
+type ThreadInstance = any;
+
+/**
+ * Map bridge permission modes to Codex approval policies.
+ * - 'acceptEdits' (code mode) → 'on-failure' (auto-approve most things)
+ * - 'plan' → 'on-request' (ask before executing)
+ * - 'default' (ask mode) → 'on-request'
+ */
+function toApprovalPolicy(permissionMode?: string): string {
+  switch (permissionMode) {
+    case 'acceptEdits': return 'on-failure';
+    case 'plan': return 'on-request';
+    case 'default': return 'on-request';
+    default: return 'on-request';
+  }
+}
+
+/** Whether to forward bridge model to Codex CLI. Default: false (use Codex current/default model). */
+function shouldPassModelToCodex(): boolean {
+  return process.env.CTI_CODEX_PASS_MODEL === 'true';
+}
+
+/** Allow Codex to run outside a trusted Git repository when explicitly enabled. */
+function shouldSkipGitRepoCheck(): boolean {
+  return process.env.CTI_CODEX_SKIP_GIT_REPO_CHECK === 'true';
+}
+
+function shouldRetryFreshThread(message: string): boolean {
+  const lower = message.toLowerCase();
+  return (
+    lower.includes('resuming session with different model') ||
+    lower.includes('no such session') ||
+    (lower.includes('resume') && lower.includes('session'))
+  );
+}
+
+export class CodexProvider implements LLMProvider {
+  private sdk: CodexModule | null = null;
+  private codex: CodexInstance | null = null;
+
+  /** Maps session IDs to Codex thread IDs for resume. */
+  private threadIds = new Map<string, string>();
+
+  constructor(private pendingPerms: PendingPermissions) {}
+
+  /**
+   * Lazily load the Codex SDK. Throws a clear error if not installed.
+   */
+  private async ensureSDK(): Promise<{ sdk: CodexModule; codex: CodexInstance }> {
+    if (this.sdk && this.codex) {
+      return { sdk: this.sdk, codex: this.codex };
+    }
+
+    try {
+      this.sdk = await (Function('return import("@openai/codex-sdk")')() as Promise<CodexModule>);
+    } catch {
+      throw new Error(
+        '[CodexProvider] @openai/codex-sdk is not installed. ' +
+        'Install it with: npm install @openai/codex-sdk'
+      );
+    }
+
+    // Resolve API key: CTI_CODEX_API_KEY > CODEX_API_KEY > OPENAI_API_KEY > (login auth)
+    const apiKey = process.env.CTI_CODEX_API_KEY
+      || process.env.CODEX_API_KEY
+      || process.env.OPENAI_API_KEY
+      || undefined;
+    const baseUrl = process.env.CTI_CODEX_BASE_URL || undefined;
+
+    const CodexClass = this.sdk.Codex;
+    this.codex = new CodexClass({
+      ...(apiKey ? { apiKey } : {}),
+      ...(baseUrl ? { baseUrl } : {}),
+    });
+
+    return { sdk: this.sdk, codex: this.codex };
+  }
+
+  streamChat(params: StreamChatParams): ReadableStream<string> {
+    const self = this;
+
+    return new ReadableStream<string>({
+      start(controller) {
+        (async () => {
+          const tempFiles: string[] = [];
+          try {
+            const { codex } = await self.ensureSDK();
+
+            // Resolve or create thread
+            const inMemoryThreadId = self.threadIds.get(params.sessionId);
+            let savedThreadId = inMemoryThreadId || params.sdkSessionId || undefined;
+
+            const approvalPolicy = toApprovalPolicy(params.permissionMode);
+            const passModel = shouldPassModelToCodex();
+
+            const threadOptions: Record<string, unknown> = {
+              ...(passModel && params.model ? { model: params.model } : {}),
+              ...(params.workingDirectory ? { workingDirectory: params.workingDirectory } : {}),
+              ...(shouldSkipGitRepoCheck() ? { skipGitRepoCheck: true } : {}),
+              approvalPolicy,
+            };
+
+            // Build input: Codex SDK UserInput supports { type: "text" } and
+            // { type: "local_image", path: string }. We write base64 data to
+            // temp files so the SDK can read them as local images.
+            // Non-image files (PDF, CSV, etc.) get their paths injected into
+            // the prompt text so the agent can read them with its Read tool.
+            const imageFiles = params.files?.filter(
+              f => f.type.startsWith('image/')
+            ) ?? [];
+            const nonImageFiles = params.files?.filter(
+              f => !f.type.startsWith('image/')
+            ) ?? [];
+
+            let promptText = params.prompt;
+            if (nonImageFiles.length > 0) {
+              const fileList = nonImageFiles
+                .filter(f => f.filePath)
+                .map(f => `- ${f.filePath} (${f.name}, ${f.type})`)
+                .join('\n');
+              if (fileList) {
+                const prefix = `The user sent the following file(s). Read them with the Read tool to see their contents:\n${fileList}\n\n`;
+                promptText = prefix + (promptText || 'Please read and analyze the attached file(s).');
+              }
+            }
+
+            let input: string | Array<Record<string, string>>;
+            if (imageFiles.length > 0) {
+              const parts: Array<Record<string, string>> = [
+                { type: 'text', text: promptText },
+              ];
+              for (const file of imageFiles) {
+                const ext = MIME_EXT[file.type] || '.png';
+                const tmpPath = path.join(os.tmpdir(), `cti-img-${Date.now()}-${Math.random().toString(36).slice(2)}${ext}`);
+                fs.writeFileSync(tmpPath, Buffer.from(file.data, 'base64'));
+                tempFiles.push(tmpPath);
+                parts.push({ type: 'local_image', path: tmpPath });
+              }
+              input = parts;
+            } else {
+              input = promptText;
+            }
+
+            let retryFresh = false;
+
+            while (true) {
+              let thread: ThreadInstance;
+              if (savedThreadId) {
+                try {
+                  thread = codex.resumeThread(savedThreadId, threadOptions);
+                } catch {
+                  thread = codex.startThread(threadOptions);
+                }
+              } else {
+                thread = codex.startThread(threadOptions);
+              }
+
+              let sawAnyEvent = false;
+              try {
+                const { events } = await thread.runStreamed(input);
+
+                for await (const event of events) {
+                  sawAnyEvent = true;
+                  if (params.abortController?.signal.aborted) {
+                    break;
+                  }
+
+                  switch (event.type) {
+                    case 'thread.started': {
+                      const threadId = event.thread_id as string;
+                      self.threadIds.set(params.sessionId, threadId);
+
+                      controller.enqueue(sseEvent('status', {
+                        session_id: threadId,
+                      }));
+                      break;
+                    }
+
+                    case 'item.completed': {
+                      const item = event.item as Record<string, unknown>;
+                      self.handleCompletedItem(controller, item);
+                      break;
+                    }
+
+                    case 'turn.completed': {
+                      const usage = event.usage as Record<string, unknown> | undefined;
+                      const threadId = self.threadIds.get(params.sessionId);
+
+                      controller.enqueue(sseEvent('result', {
+                        usage: usage ? {
+                          input_tokens: usage.input_tokens ?? 0,
+                          output_tokens: usage.output_tokens ?? 0,
+                          cache_read_input_tokens: usage.cached_input_tokens ?? 0,
+                        } : undefined,
+                        ...(threadId ? { session_id: threadId } : {}),
+                      }));
+                      break;
+                    }
+
+                    case 'turn.failed': {
+                      const error = (event as { message?: string }).message;
+                      controller.enqueue(sseEvent('error', error || 'Turn failed'));
+                      break;
+                    }
+
+                    case 'error': {
+                      const error = (event as { message?: string }).message;
+                      controller.enqueue(sseEvent('error', error || 'Thread error'));
+                      break;
+                    }
+
+                    // item.started, item.updated, turn.started — no action needed
+                  }
+                }
+                break;
+              } catch (err) {
+                const message = err instanceof Error ? err.message : String(err);
+                if (savedThreadId && !retryFresh && !sawAnyEvent && shouldRetryFreshThread(message)) {
+                  console.warn('[codex-provider] Resume failed, retrying with a fresh thread:', message);
+                  savedThreadId = undefined;
+                  retryFresh = true;
+                  continue;
+                }
+                throw err;
+              }
+            }
+
+            controller.close();
+          } catch (err) {
+            const message = err instanceof Error ? err.message : String(err);
+            console.error('[codex-provider] Error:', err instanceof Error ? err.stack || err.message : err);
+            try {
+              controller.enqueue(sseEvent('error', message));
+              controller.close();
+            } catch {
+              // Controller already closed
+            }
+          } finally {
+            // Clean up temp image files
+            for (const tmp of tempFiles) {
+              try { fs.unlinkSync(tmp); } catch { /* ignore */ }
+            }
+          }
+        })();
+      },
+    });
+  }
+
+  /**
+   * Map a completed Codex item to SSE events.
+   */
+  private handleCompletedItem(
+    controller: ReadableStreamDefaultController<string>,
+    item: Record<string, unknown>,
+  ): void {
+    const itemType = item.type as string;
+
+    switch (itemType) {
+      case 'agent_message': {
+        const text = (item.text as string) || '';
+        if (text) {
+          controller.enqueue(sseEvent('text', text));
+        }
+        break;
+      }
+
+      case 'command_execution': {
+        const toolId = (item.id as string) || `tool-${Date.now()}`;
+        const command = item.command as string || '';
+        const output = item.aggregated_output as string || '';
+        const exitCode = item.exit_code as number | undefined;
+        const isError = exitCode != null && exitCode !== 0;
+
+        controller.enqueue(sseEvent('tool_use', {
+          id: toolId,
+          name: 'Bash',
+          input: { command },
+        }));
+
+        const resultContent = output || (isError ? `Exit code: ${exitCode}` : 'Done');
+        controller.enqueue(sseEvent('tool_result', {
+          tool_use_id: toolId,
+          content: resultContent,
+          is_error: isError,
+        }));
+        break;
+      }
+
+      case 'file_change': {
+        const toolId = (item.id as string) || `tool-${Date.now()}`;
+        const changes = item.changes as Array<{ path: string; kind: string }> || [];
+        const summary = changes.map(c => `${c.kind}: ${c.path}`).join('\n');
+
+        controller.enqueue(sseEvent('tool_use', {
+          id: toolId,
+          name: 'Edit',
+          input: { files: changes },
+        }));
+
+        controller.enqueue(sseEvent('tool_result', {
+          tool_use_id: toolId,
+          content: summary || 'File changes applied',
+          is_error: false,
+        }));
+        break;
+      }
+
+      case 'mcp_tool_call': {
+        const toolId = (item.id as string) || `tool-${Date.now()}`;
+        const server = item.server as string || '';
+        const tool = item.tool as string || '';
+        const args = item.arguments as unknown;
+        const result = item.result as { content?: unknown; structured_content?: unknown } | undefined;
+        const error = item.error as { message?: string } | undefined;
+
+        const resultContent = result?.content ?? result?.structured_content;
+        const resultText = typeof resultContent === 'string' ? resultContent : (resultContent ? JSON.stringify(resultContent) : undefined);
+
+        controller.enqueue(sseEvent('tool_use', {
+          id: toolId,
+          name: `mcp__${server}__${tool}`,
+          input: args,
+        }));
+
+        controller.enqueue(sseEvent('tool_result', {
+          tool_use_id: toolId,
+          content: error?.message || resultText || 'Done',
+          is_error: !!error,
+        }));
+        break;
+      }
+
+      case 'reasoning': {
+        // Reasoning is internal; emit as status
+        const text = (item.text as string) || '';
+        if (text) {
+          controller.enqueue(sseEvent('status', { reasoning: text }));
+        }
+        break;
+      }
+    }
+  }
+}

--- a/src/codex-provider.ts
+++ b/src/codex-provider.ts
@@ -15,6 +15,7 @@ import os from 'node:os';
 import path from 'node:path';
 
 import type { LLMProvider, StreamChatParams } from 'claude-to-im/src/lib/bridge/host.js';
+import { getBridgeContext } from './lib/bridge/context.js';
 import type { PendingPermissions } from './permission-gateway.js';
 import { sseEvent } from './sse-utils.js';
 
@@ -69,6 +70,24 @@ function shouldRetryFreshThread(message: string): boolean {
   );
 }
 
+function buildProcessEnvWithLarkCliConfigDir(larkCliConfigDir: string): Record<string, string> {
+  const env: Record<string, string> = {};
+  for (const [key, value] of Object.entries(process.env)) {
+    if (value !== undefined) env[key] = value;
+  }
+  env.LARKSUITE_CLI_CONFIG_DIR = larkCliConfigDir;
+  return env;
+}
+
+function getBotLarkCliEnv(params: StreamChatParams): Record<string, string> | undefined {
+  if (!params.botName) return undefined;
+  const ctx = getBridgeContext();
+  const botConfig = ctx.feishuBotConfigs?.find(b => b.name === params.botName);
+  return botConfig?.larkCliConfigDir
+    ? buildProcessEnvWithLarkCliConfigDir(botConfig.larkCliConfigDir)
+    : undefined;
+}
+
 export class CodexProvider implements LLMProvider {
   private sdk: CodexModule | null = null;
   private codex: CodexInstance | null = null;
@@ -111,6 +130,20 @@ export class CodexProvider implements LLMProvider {
     return { sdk: this.sdk, codex: this.codex };
   }
 
+  private createCodexWithEnv(sdk: CodexModule, env: Record<string, string>): CodexInstance {
+    const apiKey = process.env.CTI_CODEX_API_KEY
+      || process.env.CODEX_API_KEY
+      || process.env.OPENAI_API_KEY
+      || undefined;
+    const baseUrl = process.env.CTI_CODEX_BASE_URL || undefined;
+    const CodexClass = sdk.Codex;
+    return new CodexClass({
+      ...(apiKey ? { apiKey } : {}),
+      ...(baseUrl ? { baseUrl } : {}),
+      env,
+    });
+  }
+
   streamChat(params: StreamChatParams): ReadableStream<string> {
     const self = this;
 
@@ -119,7 +152,9 @@ export class CodexProvider implements LLMProvider {
         (async () => {
           const tempFiles: string[] = [];
           try {
-            const { codex } = await self.ensureSDK();
+            const { sdk, codex } = await self.ensureSDK();
+            const botEnv = getBotLarkCliEnv(params);
+            const activeCodex = botEnv ? self.createCodexWithEnv(sdk, botEnv) : codex;
 
             // Resolve or create thread
             const inMemoryThreadId = self.threadIds.get(params.sessionId);
@@ -182,12 +217,12 @@ export class CodexProvider implements LLMProvider {
               let thread: ThreadInstance;
               if (savedThreadId) {
                 try {
-                  thread = codex.resumeThread(savedThreadId, threadOptions);
+                  thread = activeCodex.resumeThread(savedThreadId, threadOptions);
                 } catch {
-                  thread = codex.startThread(threadOptions);
+                  thread = activeCodex.startThread(threadOptions);
                 }
               } else {
-                thread = codex.startThread(threadOptions);
+                thread = activeCodex.startThread(threadOptions);
               }
 
               let sawAnyEvent = false;

--- a/src/config.ts
+++ b/src/config.ts
@@ -1,0 +1,280 @@
+import fs from "node:fs";
+import os from "node:os";
+import path from "node:path";
+
+export interface Config {
+  runtime: 'claude' | 'codex' | 'auto';
+  enabledChannels: string[];
+  defaultWorkDir: string;
+  defaultModel?: string;
+  defaultMode: string;
+  // Telegram
+  tgBotToken?: string;
+  tgChatId?: string;
+  tgAllowedUsers?: string[];
+  // Feishu
+  feishuAppId?: string;
+  feishuAppSecret?: string;
+  feishuDomain?: string;
+  feishuAllowedUsers?: string[];
+  // Discord
+  discordBotToken?: string;
+  discordAllowedUsers?: string[];
+  discordAllowedChannels?: string[];
+  discordAllowedGuilds?: string[];
+  // QQ
+  qqAppId?: string;
+  qqAppSecret?: string;
+  qqAllowedUsers?: string[];
+  qqImageEnabled?: boolean;
+  qqMaxImageSize?: number;
+  // WeChat
+  weixinBaseUrl?: string;
+  weixinCdnBaseUrl?: string;
+  weixinMediaEnabled?: boolean;
+  // Auto-approve all tool permission requests without user confirmation
+  autoApprove?: boolean;
+}
+
+export const CTI_HOME = process.env.CTI_HOME || path.join(os.homedir(), ".claude-to-im");
+export const CONFIG_PATH = path.join(CTI_HOME, "config.env");
+
+function parseEnvFile(content: string): Map<string, string> {
+  const entries = new Map<string, string>();
+  for (const line of content.split("\n")) {
+    const trimmed = line.trim();
+    if (!trimmed || trimmed.startsWith("#")) continue;
+    const eqIdx = trimmed.indexOf("=");
+    if (eqIdx === -1) continue;
+    const key = trimmed.slice(0, eqIdx).trim();
+    let value = trimmed.slice(eqIdx + 1).trim();
+    // Strip surrounding quotes
+    if (
+      (value.startsWith('"') && value.endsWith('"')) ||
+      (value.startsWith("'") && value.endsWith("'"))
+    ) {
+      value = value.slice(1, -1);
+    }
+    entries.set(key, value);
+  }
+  return entries;
+}
+
+function splitCsv(value: string | undefined): string[] | undefined {
+  if (!value) return undefined;
+  return value
+    .split(",")
+    .map((s) => s.trim())
+    .filter(Boolean);
+}
+
+export function loadConfig(): Config {
+  let env = new Map<string, string>();
+  try {
+    const content = fs.readFileSync(CONFIG_PATH, "utf-8");
+    env = parseEnvFile(content);
+  } catch {
+    // Config file doesn't exist yet — use defaults
+  }
+
+  const rawRuntime = env.get("CTI_RUNTIME") || "claude";
+  const runtime = (["claude", "codex", "auto"].includes(rawRuntime) ? rawRuntime : "claude") as Config["runtime"];
+
+  return {
+    runtime,
+    enabledChannels: splitCsv(env.get("CTI_ENABLED_CHANNELS")) ?? [],
+    defaultWorkDir: env.get("CTI_DEFAULT_WORKDIR") || process.cwd(),
+    defaultModel: env.get("CTI_DEFAULT_MODEL") || undefined,
+    defaultMode: env.get("CTI_DEFAULT_MODE") || "code",
+    tgBotToken: env.get("CTI_TG_BOT_TOKEN") || undefined,
+    tgChatId: env.get("CTI_TG_CHAT_ID") || undefined,
+    tgAllowedUsers: splitCsv(env.get("CTI_TG_ALLOWED_USERS")),
+    feishuAppId: env.get("CTI_FEISHU_APP_ID") || undefined,
+    feishuAppSecret: env.get("CTI_FEISHU_APP_SECRET") || undefined,
+    feishuDomain: env.get("CTI_FEISHU_DOMAIN") || undefined,
+    feishuAllowedUsers: splitCsv(env.get("CTI_FEISHU_ALLOWED_USERS")),
+    discordBotToken: env.get("CTI_DISCORD_BOT_TOKEN") || undefined,
+    discordAllowedUsers: splitCsv(env.get("CTI_DISCORD_ALLOWED_USERS")),
+    discordAllowedChannels: splitCsv(
+      env.get("CTI_DISCORD_ALLOWED_CHANNELS")
+    ),
+    discordAllowedGuilds: splitCsv(env.get("CTI_DISCORD_ALLOWED_GUILDS")),
+    qqAppId: env.get("CTI_QQ_APP_ID") || undefined,
+    qqAppSecret: env.get("CTI_QQ_APP_SECRET") || undefined,
+    qqAllowedUsers: splitCsv(env.get("CTI_QQ_ALLOWED_USERS")),
+    qqImageEnabled: env.has("CTI_QQ_IMAGE_ENABLED")
+      ? env.get("CTI_QQ_IMAGE_ENABLED") === "true"
+      : undefined,
+    qqMaxImageSize: env.get("CTI_QQ_MAX_IMAGE_SIZE")
+      ? Number(env.get("CTI_QQ_MAX_IMAGE_SIZE"))
+      : undefined,
+    weixinBaseUrl: env.get("CTI_WEIXIN_BASE_URL") || undefined,
+    weixinCdnBaseUrl: env.get("CTI_WEIXIN_CDN_BASE_URL") || undefined,
+    weixinMediaEnabled: env.has("CTI_WEIXIN_MEDIA_ENABLED")
+      ? env.get("CTI_WEIXIN_MEDIA_ENABLED") === "true"
+      : undefined,
+    autoApprove: env.get("CTI_AUTO_APPROVE") === "true",
+  };
+}
+
+function formatEnvLine(key: string, value: string | undefined): string {
+  if (value === undefined || value === "") return "";
+  return `${key}=${value}\n`;
+}
+
+export function saveConfig(config: Config): void {
+  let out = "";
+  out += formatEnvLine("CTI_RUNTIME", config.runtime);
+  out += formatEnvLine(
+    "CTI_ENABLED_CHANNELS",
+    config.enabledChannels.join(",")
+  );
+  out += formatEnvLine("CTI_DEFAULT_WORKDIR", config.defaultWorkDir);
+  if (config.defaultModel) out += formatEnvLine("CTI_DEFAULT_MODEL", config.defaultModel);
+  out += formatEnvLine("CTI_DEFAULT_MODE", config.defaultMode);
+  out += formatEnvLine("CTI_TG_BOT_TOKEN", config.tgBotToken);
+  out += formatEnvLine("CTI_TG_CHAT_ID", config.tgChatId);
+  out += formatEnvLine(
+    "CTI_TG_ALLOWED_USERS",
+    config.tgAllowedUsers?.join(",")
+  );
+  out += formatEnvLine("CTI_FEISHU_APP_ID", config.feishuAppId);
+  out += formatEnvLine("CTI_FEISHU_APP_SECRET", config.feishuAppSecret);
+  out += formatEnvLine("CTI_FEISHU_DOMAIN", config.feishuDomain);
+  out += formatEnvLine(
+    "CTI_FEISHU_ALLOWED_USERS",
+    config.feishuAllowedUsers?.join(",")
+  );
+  out += formatEnvLine("CTI_DISCORD_BOT_TOKEN", config.discordBotToken);
+  out += formatEnvLine(
+    "CTI_DISCORD_ALLOWED_USERS",
+    config.discordAllowedUsers?.join(",")
+  );
+  out += formatEnvLine(
+    "CTI_DISCORD_ALLOWED_CHANNELS",
+    config.discordAllowedChannels?.join(",")
+  );
+  out += formatEnvLine(
+    "CTI_DISCORD_ALLOWED_GUILDS",
+    config.discordAllowedGuilds?.join(",")
+  );
+  out += formatEnvLine("CTI_QQ_APP_ID", config.qqAppId);
+  out += formatEnvLine("CTI_QQ_APP_SECRET", config.qqAppSecret);
+  out += formatEnvLine(
+    "CTI_QQ_ALLOWED_USERS",
+    config.qqAllowedUsers?.join(",")
+  );
+  if (config.qqImageEnabled !== undefined)
+    out += formatEnvLine("CTI_QQ_IMAGE_ENABLED", String(config.qqImageEnabled));
+  if (config.qqMaxImageSize !== undefined)
+    out += formatEnvLine("CTI_QQ_MAX_IMAGE_SIZE", String(config.qqMaxImageSize));
+  out += formatEnvLine("CTI_WEIXIN_BASE_URL", config.weixinBaseUrl);
+  out += formatEnvLine("CTI_WEIXIN_CDN_BASE_URL", config.weixinCdnBaseUrl);
+  if (config.weixinMediaEnabled !== undefined)
+    out += formatEnvLine("CTI_WEIXIN_MEDIA_ENABLED", String(config.weixinMediaEnabled));
+
+  fs.mkdirSync(CTI_HOME, { recursive: true });
+  const tmpPath = CONFIG_PATH + ".tmp";
+  fs.writeFileSync(tmpPath, out, { mode: 0o600 });
+  fs.renameSync(tmpPath, CONFIG_PATH);
+}
+
+export function maskSecret(value: string): string {
+  if (value.length <= 4) return "****";
+  return "*".repeat(value.length - 4) + value.slice(-4);
+}
+
+export function configToSettings(config: Config): Map<string, string> {
+  const m = new Map<string, string>();
+  m.set("remote_bridge_enabled", "true");
+
+  // ── Telegram ──
+  // Upstream keys: telegram_bot_token, bridge_telegram_enabled,
+  //   telegram_bridge_allowed_users, telegram_chat_id
+  m.set(
+    "bridge_telegram_enabled",
+    config.enabledChannels.includes("telegram") ? "true" : "false"
+  );
+  if (config.tgBotToken) m.set("telegram_bot_token", config.tgBotToken);
+  if (config.tgAllowedUsers)
+    m.set("telegram_bridge_allowed_users", config.tgAllowedUsers.join(","));
+  if (config.tgChatId) m.set("telegram_chat_id", config.tgChatId);
+
+  // ── Discord ──
+  // Upstream keys: bridge_discord_bot_token, bridge_discord_enabled,
+  //   bridge_discord_allowed_users, bridge_discord_allowed_channels,
+  //   bridge_discord_allowed_guilds
+  m.set(
+    "bridge_discord_enabled",
+    config.enabledChannels.includes("discord") ? "true" : "false"
+  );
+  if (config.discordBotToken)
+    m.set("bridge_discord_bot_token", config.discordBotToken);
+  if (config.discordAllowedUsers)
+    m.set("bridge_discord_allowed_users", config.discordAllowedUsers.join(","));
+  if (config.discordAllowedChannels)
+    m.set(
+      "bridge_discord_allowed_channels",
+      config.discordAllowedChannels.join(",")
+    );
+  if (config.discordAllowedGuilds)
+    m.set(
+      "bridge_discord_allowed_guilds",
+      config.discordAllowedGuilds.join(",")
+    );
+
+  // ── Feishu ──
+  // Upstream keys: bridge_feishu_app_id, bridge_feishu_app_secret,
+  //   bridge_feishu_domain, bridge_feishu_enabled, bridge_feishu_allowed_users
+  m.set(
+    "bridge_feishu_enabled",
+    config.enabledChannels.includes("feishu") ? "true" : "false"
+  );
+  if (config.feishuAppId) m.set("bridge_feishu_app_id", config.feishuAppId);
+  if (config.feishuAppSecret)
+    m.set("bridge_feishu_app_secret", config.feishuAppSecret);
+  if (config.feishuDomain) m.set("bridge_feishu_domain", config.feishuDomain);
+  if (config.feishuAllowedUsers)
+    m.set("bridge_feishu_allowed_users", config.feishuAllowedUsers.join(","));
+
+  // ── QQ ──
+  // Upstream keys: bridge_qq_enabled, bridge_qq_app_id, bridge_qq_app_secret,
+  //   bridge_qq_allowed_users, bridge_qq_image_enabled, bridge_qq_max_image_size
+  m.set(
+    "bridge_qq_enabled",
+    config.enabledChannels.includes("qq") ? "true" : "false"
+  );
+  if (config.qqAppId) m.set("bridge_qq_app_id", config.qqAppId);
+  if (config.qqAppSecret) m.set("bridge_qq_app_secret", config.qqAppSecret);
+  if (config.qqAllowedUsers)
+    m.set("bridge_qq_allowed_users", config.qqAllowedUsers.join(","));
+  if (config.qqImageEnabled !== undefined)
+    m.set("bridge_qq_image_enabled", String(config.qqImageEnabled));
+  if (config.qqMaxImageSize !== undefined)
+    m.set("bridge_qq_max_image_size", String(config.qqMaxImageSize));
+
+  // ── WeChat ──
+  // Upstream keys: bridge_weixin_enabled, bridge_weixin_media_enabled,
+  //   bridge_weixin_base_url, bridge_weixin_cdn_base_url
+  m.set(
+    "bridge_weixin_enabled",
+    config.enabledChannels.includes("weixin") ? "true" : "false"
+  );
+  if (config.weixinMediaEnabled !== undefined)
+    m.set("bridge_weixin_media_enabled", String(config.weixinMediaEnabled));
+  if (config.weixinBaseUrl)
+    m.set("bridge_weixin_base_url", config.weixinBaseUrl);
+  if (config.weixinCdnBaseUrl)
+    m.set("bridge_weixin_cdn_base_url", config.weixinCdnBaseUrl);
+
+  // ── Defaults ──
+  // Upstream keys: bridge_default_work_dir, bridge_default_model, default_model
+  m.set("bridge_default_work_dir", config.defaultWorkDir);
+  if (config.defaultModel) {
+    m.set("bridge_default_model", config.defaultModel);
+    m.set("default_model", config.defaultModel);
+  }
+  m.set("bridge_default_mode", config.defaultMode);
+
+  return m;
+}

--- a/src/config.ts
+++ b/src/config.ts
@@ -34,6 +34,17 @@ export interface Config {
   weixinMediaEnabled?: boolean;
   // Auto-approve all tool permission requests without user confirmation
   autoApprove?: boolean;
+  // -- Content Guard (prompt injection detection) --
+  /** Enable content guard for external data scanning. Default true. */
+  injectionGuardEnabled?: boolean;
+  /** MiniMax API key for LLM-based classification (stage 2). */
+  minimaxApiKey?: string;
+  /** MiniMax API base URL override. */
+  minimaxBaseUrl?: string;
+  /** MiniMax model override. Default MiniMax-M1. */
+  minimaxModel?: string;
+  /** Score threshold for blocking content outright. Default 15. */
+  injectionBlockThreshold?: number;
 }
 
 export const CTI_HOME = process.env.CTI_HOME || path.join(os.homedir(), ".claude-to-im");
@@ -114,6 +125,16 @@ export function loadConfig(): Config {
       ? env.get("CTI_WEIXIN_MEDIA_ENABLED") === "true"
       : undefined,
     autoApprove: env.get("CTI_AUTO_APPROVE") === "true",
+    // Content Guard
+    injectionGuardEnabled: env.has("CTI_INJECTION_GUARD_ENABLED")
+      ? env.get("CTI_INJECTION_GUARD_ENABLED") !== "false"
+      : true, // enabled by default
+    minimaxApiKey: process.env.CTI_MINIMAX_API_KEY || env.get("CTI_MINIMAX_API_KEY") || undefined,
+    minimaxBaseUrl: env.get("CTI_MINIMAX_BASE_URL") || undefined,
+    minimaxModel: env.get("CTI_MINIMAX_MODEL") || undefined,
+    injectionBlockThreshold: env.get("CTI_INJECTION_BLOCK_THRESHOLD")
+      ? Number(env.get("CTI_INJECTION_BLOCK_THRESHOLD"))
+      : undefined,
   };
 }
 
@@ -172,6 +193,15 @@ export function saveConfig(config: Config): void {
   out += formatEnvLine("CTI_WEIXIN_CDN_BASE_URL", config.weixinCdnBaseUrl);
   if (config.weixinMediaEnabled !== undefined)
     out += formatEnvLine("CTI_WEIXIN_MEDIA_ENABLED", String(config.weixinMediaEnabled));
+
+  // Content Guard
+  if (config.injectionGuardEnabled !== undefined)
+    out += formatEnvLine("CTI_INJECTION_GUARD_ENABLED", String(config.injectionGuardEnabled));
+  out += formatEnvLine("CTI_MINIMAX_API_KEY", config.minimaxApiKey);
+  out += formatEnvLine("CTI_MINIMAX_BASE_URL", config.minimaxBaseUrl);
+  out += formatEnvLine("CTI_MINIMAX_MODEL", config.minimaxModel);
+  if (config.injectionBlockThreshold !== undefined)
+    out += formatEnvLine("CTI_INJECTION_BLOCK_THRESHOLD", String(config.injectionBlockThreshold));
 
   fs.mkdirSync(CTI_HOME, { recursive: true });
   const tmpPath = CONFIG_PATH + ".tmp";

--- a/src/config.ts
+++ b/src/config.ts
@@ -17,6 +17,7 @@ export interface Config {
   feishuAppSecret?: string;
   feishuDomain?: string;
   feishuAllowedUsers?: string[];
+  feishuRequireMention?: boolean;
   // Discord
   discordBotToken?: string;
   discordAllowedUsers?: string[];
@@ -104,6 +105,9 @@ export function loadConfig(): Config {
     feishuAppSecret: env.get("CTI_FEISHU_APP_SECRET") || undefined,
     feishuDomain: env.get("CTI_FEISHU_DOMAIN") || undefined,
     feishuAllowedUsers: splitCsv(env.get("CTI_FEISHU_ALLOWED_USERS")),
+    feishuRequireMention: env.has("CTI_FEISHU_REQUIRE_MENTION")
+      ? env.get("CTI_FEISHU_REQUIRE_MENTION") !== "false"
+      : undefined,
     discordBotToken: env.get("CTI_DISCORD_BOT_TOKEN") || undefined,
     discordAllowedUsers: splitCsv(env.get("CTI_DISCORD_ALLOWED_USERS")),
     discordAllowedChannels: splitCsv(
@@ -166,6 +170,8 @@ export function saveConfig(config: Config): void {
     "CTI_FEISHU_ALLOWED_USERS",
     config.feishuAllowedUsers?.join(",")
   );
+  if (config.feishuRequireMention !== undefined)
+    out += formatEnvLine("CTI_FEISHU_REQUIRE_MENTION", String(config.feishuRequireMention));
   out += formatEnvLine("CTI_DISCORD_BOT_TOKEN", config.discordBotToken);
   out += formatEnvLine(
     "CTI_DISCORD_ALLOWED_USERS",
@@ -266,6 +272,8 @@ export function configToSettings(config: Config): Map<string, string> {
   if (config.feishuDomain) m.set("bridge_feishu_domain", config.feishuDomain);
   if (config.feishuAllowedUsers)
     m.set("bridge_feishu_allowed_users", config.feishuAllowedUsers.join(","));
+  if (config.feishuRequireMention !== undefined)
+    m.set("bridge_feishu_require_mention", String(config.feishuRequireMention));
 
   // ── QQ ──
   // Upstream keys: bridge_qq_enabled, bridge_qq_app_id, bridge_qq_app_secret,

--- a/src/config.ts
+++ b/src/config.ts
@@ -9,6 +9,7 @@ export interface Config {
   defaultWorkDir: string;
   defaultModel?: string;
   defaultMode: string;
+  feishuBotConfigs?: FeishuBotConfig[];
   // Telegram
   tgBotToken?: string;
   tgChatId?: string;
@@ -155,6 +156,7 @@ export function loadConfig(): Config {
 
   const rawRuntime = env.get("CTI_RUNTIME") || "claude";
   const runtime = (["claude", "codex", "auto"].includes(rawRuntime) ? rawRuntime : "claude") as Config["runtime"];
+  const feishuBotConfigs = parseFeishuBotConfigs(env);
 
   return {
     runtime,
@@ -162,6 +164,7 @@ export function loadConfig(): Config {
     defaultWorkDir: env.get("CTI_DEFAULT_WORKDIR") || process.cwd(),
     defaultModel: env.get("CTI_DEFAULT_MODEL") || undefined,
     defaultMode: env.get("CTI_DEFAULT_MODE") || "code",
+    feishuBotConfigs,
     tgBotToken: env.get("CTI_TG_BOT_TOKEN") || undefined,
     tgChatId: env.get("CTI_TG_CHAT_ID") || undefined,
     tgAllowedUsers: splitCsv(env.get("CTI_TG_ALLOWED_USERS")),
@@ -286,6 +289,7 @@ export function maskSecret(value: string): string {
 
 export function configToSettings(config: Config): Map<string, string> {
   const m = new Map<string, string>();
+  m.set("CTI_HOME", CTI_HOME);
   m.set("remote_bridge_enabled", "true");
 
   // ── Telegram ──
@@ -338,6 +342,24 @@ export function configToSettings(config: Config): Map<string, string> {
     m.set("bridge_feishu_allowed_users", config.feishuAllowedUsers.join(","));
   if (config.feishuRequireMention !== undefined)
     m.set("bridge_feishu_require_mention", String(config.feishuRequireMention));
+  (config.feishuBotConfigs ?? []).forEach((bot, index) => {
+    const prefix = `CTI_FEISHU_BOTS_${index}_`;
+    m.set(`${prefix}NAME`, bot.name);
+    m.set(`${prefix}APP_ID`, bot.appId);
+    m.set(`${prefix}APP_SECRET`, bot.appSecret);
+    if (bot.domain) m.set(`${prefix}DOMAIN`, bot.domain);
+    if (bot.allowedUsers) m.set(`${prefix}ALLOWED_USERS`, bot.allowedUsers.join(","));
+    if (bot.requireMention !== undefined)
+      m.set(`${prefix}REQUIRE_MENTION`, String(bot.requireMention));
+    if (bot.groupPolicy) m.set(`${prefix}GROUP_POLICY`, bot.groupPolicy);
+    if (bot.groupAllowFrom) m.set(`${prefix}GROUP_ALLOW_FROM`, bot.groupAllowFrom.join(","));
+    if (bot.workingDirectory) m.set(`${prefix}WORKING_DIR`, bot.workingDirectory);
+    for (const [userId, override] of bot.userOverrides ?? []) {
+      if (override.workingDirectory) {
+        m.set(`${prefix}USER_${userId}_WORKING_DIR`, override.workingDirectory);
+      }
+    }
+  });
 
   // ── QQ ──
   // Upstream keys: bridge_qq_enabled, bridge_qq_app_id, bridge_qq_app_secret,

--- a/src/config.ts
+++ b/src/config.ts
@@ -144,6 +144,7 @@ export function parseFeishuBotConfigs(env: Map<string, string>): FeishuBotConfig
           if (!wd) throw new Error(`${prefix}WORKING_DIR is required (each bot must have its own working directory)`);
           return wd;
         })(),
+        larkCliConfigDir: env.get(`${prefix}LARK_CLI_CONFIG_DIR`) || undefined,
         userOverrides: userOverrides.size > 0 ? userOverrides : undefined,
       } satisfies FeishuBotConfig;
     });

--- a/src/config.ts
+++ b/src/config.ts
@@ -139,7 +139,11 @@ export function parseFeishuBotConfigs(env: Map<string, string>): FeishuBotConfig
           : undefined,
         groupPolicy,
         groupAllowFrom: splitCsv(env.get(`${prefix}GROUP_ALLOW_FROM`)),
-        workingDirectory: env.get(`${prefix}WORKING_DIR`) || undefined,
+        workingDirectory: (() => {
+          const wd = env.get(`${prefix}WORKING_DIR`);
+          if (!wd) throw new Error(`${prefix}WORKING_DIR is required (each bot must have its own working directory)`);
+          return wd;
+        })(),
         userOverrides: userOverrides.size > 0 ? userOverrides : undefined,
       } satisfies FeishuBotConfig;
     });

--- a/src/config.ts
+++ b/src/config.ts
@@ -1,6 +1,7 @@
 import fs from "node:fs";
 import os from "node:os";
 import path from "node:path";
+import type { FeishuBotConfig } from "./lib/bridge/types";
 
 export interface Config {
   runtime: 'claude' | 'codex' | 'auto';
@@ -78,6 +79,69 @@ function splitCsv(value: string | undefined): string[] | undefined {
     .split(",")
     .map((s) => s.trim())
     .filter(Boolean);
+}
+
+export function parseFeishuBotConfigs(env: Map<string, string>): FeishuBotConfig[] {
+  const hasLegacy = env.has("CTI_FEISHU_APP_ID") || env.has("CTI_FEISHU_APP_SECRET");
+  const hasBot0Name = env.has("CTI_FEISHU_BOTS_0_NAME");
+
+  if (hasLegacy && !hasBot0Name) {
+    throw new Error(
+      "Legacy single-bot config detected (CTI_FEISHU_APP_ID). " +
+        "Run migrate-to-multi-bot.sh to convert to the new multi-bot format (CTI_FEISHU_BOTS_N_*)."
+    );
+  }
+
+  const indices = new Set<number>();
+  for (const key of env.keys()) {
+    const match = key.match(/^CTI_FEISHU_BOTS_(\d+)_/);
+    if (match) indices.add(Number.parseInt(match[1], 10));
+  }
+
+  if (indices.size === 0) return [];
+
+  return Array.from(indices)
+    .sort((a, b) => a - b)
+    .map((index) => {
+      const prefix = `CTI_FEISHU_BOTS_${index}_`;
+      const name = env.get(`${prefix}NAME`);
+      if (!name) throw new Error(`${prefix}NAME is required`);
+
+      const appId = env.get(`${prefix}APP_ID`);
+      if (!appId) throw new Error(`${prefix}APP_ID is required`);
+
+      const appSecret = env.get(`${prefix}APP_SECRET`);
+      if (!appSecret) throw new Error(`${prefix}APP_SECRET is required`);
+
+      const domain = env.get(`${prefix}DOMAIN`) as FeishuBotConfig["domain"];
+      const groupPolicy = env.get(`${prefix}GROUP_POLICY`) as FeishuBotConfig["groupPolicy"];
+      const userOverrides = new Map<string, { workingDirectory?: string }>();
+      const userOverridePattern = new RegExp(
+        `^${prefix.replace(/[.*+?^${}()|[\]\\]/g, "\\$&")}USER_(.+)_WORKING_DIR$`
+      );
+
+      for (const [key, value] of env) {
+        const match = key.match(userOverridePattern);
+        if (match) {
+          userOverrides.set(match[1], { workingDirectory: value });
+        }
+      }
+
+      return {
+        name,
+        appId,
+        appSecret,
+        domain,
+        allowedUsers: splitCsv(env.get(`${prefix}ALLOWED_USERS`)),
+        requireMention: env.has(`${prefix}REQUIRE_MENTION`)
+          ? env.get(`${prefix}REQUIRE_MENTION`) === "true"
+          : undefined,
+        groupPolicy,
+        groupAllowFrom: splitCsv(env.get(`${prefix}GROUP_ALLOW_FROM`)),
+        workingDirectory: env.get(`${prefix}WORKING_DIR`) || undefined,
+        userOverrides: userOverrides.size > 0 ? userOverrides : undefined,
+      } satisfies FeishuBotConfig;
+    });
 }
 
 export function loadConfig(): Config {

--- a/src/lib/bridge/adapters/feishu-adapter.ts
+++ b/src/lib/bridge/adapters/feishu-adapter.ts
@@ -16,6 +16,8 @@
  */
 
 import crypto from 'crypto';
+import fs from 'fs';
+import path from 'path';
 import * as lark from '@larksuiteoapi/node-sdk';
 import type {
   ChannelType,
@@ -44,6 +46,22 @@ const DEDUP_MAX = 1000;
 
 /** Max file download size (20 MB). */
 const MAX_FILE_SIZE = 20 * 1024 * 1024;
+
+/** Max image upload size for Feishu (10 MB). */
+const MAX_IMAGE_UPLOAD_SIZE = 10 * 1024 * 1024;
+
+/** Max file upload size for Feishu (30 MB). */
+const MAX_FILE_UPLOAD_SIZE = 30 * 1024 * 1024;
+
+/** Feishu file_type mapping by extension. */
+const FEISHU_FILE_TYPE: Record<string, string> = {
+  '.mp4': 'mp4',
+  '.pdf': 'pdf',
+  '.doc': 'doc', '.docx': 'doc',
+  '.xls': 'xls', '.xlsx': 'xls',
+  '.ppt': 'ppt', '.pptx': 'ppt',
+  '.mp3': 'opus', '.ogg': 'opus', '.wav': 'opus',
+};
 
 /** Feishu emoji type for typing indicator (same as Openclaw). */
 const TYPING_EMOJI = 'Typing';
@@ -654,6 +672,132 @@ export class FeishuAdapter extends BaseChannelAdapter {
       return this.sendAsCard(message.address.chatId, text);
     }
     return this.sendAsPost(message.address.chatId, text);
+  }
+
+  /**
+   * Send a file (image or document) to a Feishu chat.
+   * Images are uploaded via im.image.create, files via im.file.create.
+   */
+  async sendFile(chatId: string, filePath: string, fileName: string): Promise<SendResult> {
+    if (!this.restClient) {
+      return { ok: false, error: 'Feishu client not initialized' };
+    }
+
+    // Check file exists
+    let stat: fs.Stats;
+    try {
+      stat = fs.statSync(filePath);
+    } catch {
+      console.warn(`[feishu-adapter] sendFile: file not found: ${filePath}`);
+      return { ok: false, error: `File not found: ${filePath}` };
+    }
+
+    const ext = path.extname(filePath).toLowerCase();
+    const isImage = ['.png', '.jpg', '.jpeg', '.gif', '.webp', '.bmp', '.tiff', '.ico'].includes(ext);
+
+    if (isImage) {
+      return this.uploadAndSendImage(chatId, filePath, stat.size);
+    }
+    return this.uploadAndSendFile(chatId, filePath, fileName, ext, stat.size);
+  }
+
+  /**
+   * Upload image to Feishu and send as image message.
+   */
+  private async uploadAndSendImage(chatId: string, filePath: string, fileSize: number): Promise<SendResult> {
+    if (fileSize > MAX_IMAGE_UPLOAD_SIZE) {
+      console.warn(`[feishu-adapter] Image too large (${fileSize} bytes > ${MAX_IMAGE_UPLOAD_SIZE}): ${filePath}`);
+      return { ok: false, error: `Image exceeds 10MB limit` };
+    }
+
+    try {
+      // Upload image via Feishu SDK: POST /open-apis/im/v1/images
+      const uploadRes = await this.restClient!.im.image.create({
+        data: {
+          image_type: 'message',
+          image: fs.createReadStream(filePath),
+        },
+      });
+
+      const imageKey = (uploadRes as any)?.image_key || (uploadRes as any)?.data?.image_key;
+      if (!imageKey) {
+        console.warn('[feishu-adapter] Image upload returned no image_key:', uploadRes);
+        return { ok: false, error: 'Image upload failed: no image_key returned' };
+      }
+
+      // Send image message
+      const sendRes = await this.restClient!.im.message.create({
+        params: { receive_id_type: 'chat_id' },
+        data: {
+          receive_id: chatId,
+          msg_type: 'image',
+          content: JSON.stringify({ image_key: imageKey }),
+        },
+      });
+
+      if (sendRes?.data?.message_id) {
+        console.log(`[feishu-adapter] Image sent: ${filePath} → ${imageKey}`);
+        return { ok: true, messageId: sendRes.data.message_id };
+      }
+      return { ok: false, error: sendRes?.msg || 'Image send failed' };
+    } catch (err) {
+      console.error('[feishu-adapter] Image upload/send error:', err instanceof Error ? err.message : err);
+      return { ok: false, error: err instanceof Error ? err.message : 'Image send failed' };
+    }
+  }
+
+  /**
+   * Upload file to Feishu and send as file message.
+   */
+  private async uploadAndSendFile(
+    chatId: string,
+    filePath: string,
+    fileName: string,
+    ext: string,
+    fileSize: number,
+  ): Promise<SendResult> {
+    if (fileSize > MAX_FILE_UPLOAD_SIZE) {
+      console.warn(`[feishu-adapter] File too large (${fileSize} bytes > ${MAX_FILE_UPLOAD_SIZE}): ${filePath}`);
+      return { ok: false, error: `File exceeds 30MB limit` };
+    }
+
+    const fileType = FEISHU_FILE_TYPE[ext] || 'stream';
+
+    try {
+      // Upload file via Feishu SDK: POST /open-apis/im/v1/files
+      const uploadRes = await this.restClient!.im.file.create({
+        data: {
+          file_type: fileType as any,
+          file_name: fileName,
+          file: fs.createReadStream(filePath),
+        },
+      });
+
+      const fileKey = (uploadRes as any)?.file_key || (uploadRes as any)?.data?.file_key;
+      if (!fileKey) {
+        console.warn('[feishu-adapter] File upload returned no file_key:', uploadRes);
+        return { ok: false, error: 'File upload failed: no file_key returned' };
+      }
+
+      // Send file message
+      const sendRes = await this.restClient!.im.message.create({
+        params: { receive_id_type: 'chat_id' },
+        data: {
+          receive_id: chatId,
+          msg_type: 'file',
+          content: JSON.stringify({ file_key: fileKey }),
+        },
+      });
+
+      if (sendRes?.data?.message_id) {
+        console.log(`[feishu-adapter] File sent: ${filePath} → ${fileKey}`);
+        return { ok: true, messageId: sendRes.data.message_id };
+      }
+      return { ok: false, error: sendRes?.msg || 'File send failed' };
+    } catch (err) {
+      console.error('[feishu-adapter] File upload/send error:', err instanceof Error ? err.message : err);
+      return { ok: false, error: err instanceof Error ? err.message : 'File send failed' };
+    }
   }
 
   /**

--- a/src/lib/bridge/adapters/feishu-adapter.ts
+++ b/src/lib/bridge/adapters/feishu-adapter.ts
@@ -1103,8 +1103,14 @@ export class FeishuAdapter extends BaseChannelAdapter {
         }
       }
 
-      // Require @mention check
-      const requireMention = getBridgeContext().store.getSetting('bridge_feishu_require_mention') !== 'false';
+      // Require @mention check (store setting > env var > default true)
+      const storeSetting = getBridgeContext().store.getSetting('bridge_feishu_require_mention');
+      const envSetting = process.env.CTI_FEISHU_REQUIRE_MENTION;
+      const requireMention = storeSetting !== null
+        ? storeSetting !== 'false'
+        : envSetting !== undefined
+          ? envSetting !== 'false'
+          : true;
       if (requireMention && !this.isBotMentioned(msg.mentions)) {
         console.log('[feishu-adapter] Group message ignored (bot not @mentioned), chatId:', chatId, 'msgId:', msg.message_id);
         try {

--- a/src/lib/bridge/adapters/feishu-adapter.ts
+++ b/src/lib/bridge/adapters/feishu-adapter.ts
@@ -411,7 +411,7 @@ export class FeishuAdapter extends BaseChannelAdapter {
         },
       };
 
-      const createResp = await (this.restClient as any).cardkit.v2.card.create({
+      const createResp = await (this.restClient as any).cardkit.v1.card.create({
         data: { type: 'card_json', data: JSON.stringify(cardBody) },
       });
       const cardId = createResp?.data?.card_id;
@@ -513,8 +513,8 @@ export class FeishuAdapter extends BaseChannelAdapter {
     const cardId = state.cardId;
 
     // Fire-and-forget — streaming updates are non-critical
-    (this.restClient as any).cardkit.v2.card.streamContent({
-      path: { card_id: cardId },
+    (this.restClient as any).cardkit.v1.cardElement.content({
+      path: { card_id: cardId, element_id: 'streaming_content' },
       data: { content, sequence: seq },
     }).then(() => {
       state.lastUpdateAt = Date.now();
@@ -560,9 +560,9 @@ export class FeishuAdapter extends BaseChannelAdapter {
     try {
       // Step 1: Close streaming mode
       state.sequence++;
-      await (this.restClient as any).cardkit.v2.card.settings.streamingMode.set({
+      await (this.restClient as any).cardkit.v1.card.settings({
         path: { card_id: state.cardId },
-        data: { streaming_mode: false, sequence: state.sequence },
+        data: { settings: JSON.stringify({ streaming_mode: false }), sequence: state.sequence },
       });
 
       // Step 2: Build and apply final card
@@ -580,9 +580,9 @@ export class FeishuAdapter extends BaseChannelAdapter {
       const finalCardJson = buildFinalCardJson(responseText, state.toolCalls, footer);
 
       state.sequence++;
-      await (this.restClient as any).cardkit.v2.card.update({
+      await (this.restClient as any).cardkit.v1.card.update({
         path: { card_id: state.cardId },
-        data: { type: 'card_json', data: finalCardJson, sequence: state.sequence },
+        data: { card: { type: 'card_json', data: finalCardJson }, sequence: state.sequence },
       });
 
       console.log(`[feishu-adapter] Card finalized: cardId=${state.cardId}, status=${status}, elapsed=${formatElapsed(elapsedMs)}`);
@@ -1158,11 +1158,39 @@ export class FeishuAdapter extends BaseChannelAdapter {
           } catch { /* best effort */ }
         }
       }
-    } else if (messageType === 'file' || messageType === 'audio' || messageType === 'video' || messageType === 'media') {
-      // [P2] Support file/audio/video/media downloads
+    } else if (messageType === 'audio') {
+      // [P2] Voice message → STT via DashScope qwen-omni-turbo
       const fileKey = this.extractFileKey(msg.content);
       if (fileKey) {
-        const resourceType = messageType === 'audio' || messageType === 'video' || messageType === 'media'
+        const attachment = await this.downloadResource(msg.message_id, fileKey, 'audio');
+        if (attachment) {
+          const transcript = await this.transcribeAudio(attachment.data);
+          if (transcript) {
+            text = transcript;
+            console.log(`[feishu-adapter] Voice STT success (${transcript.length} chars): ${transcript.slice(0, 80)}`);
+          } else {
+            // STT failed, fall back to attaching audio file
+            attachments.push(attachment);
+            console.warn('[feishu-adapter] Voice STT failed, falling back to audio attachment');
+          }
+        } else {
+          text = '[audio download failed]';
+          try {
+            getBridgeContext().store.insertAuditLog({
+              channelType: 'feishu',
+              chatId,
+              direction: 'inbound',
+              messageId: msg.message_id,
+              summary: `[ERROR] audio download failed for key: ${fileKey}`,
+            });
+          } catch { /* best effort */ }
+        }
+      }
+    } else if (messageType === 'file' || messageType === 'video' || messageType === 'media') {
+      // [P2] Support file/video/media downloads
+      const fileKey = this.extractFileKey(msg.content);
+      if (fileKey) {
+        const resourceType = messageType === 'video' || messageType === 'media'
           ? messageType
           : 'file';
         const attachment = await this.downloadResource(msg.message_id, fileKey, resourceType);
@@ -1392,6 +1420,69 @@ export class FeishuAdapter extends BaseChannelAdapter {
   private stripMentionMarkers(text: string): string {
     // Feishu uses @_user_N placeholders for mentions
     return text.replace(/@_user_\d+/g, '').trim();
+  }
+
+  // ── Voice STT (Speech-to-Text) ──────────────────────────────
+
+  /**
+   * Transcribe audio (base64-encoded) to text via DashScope qwen-omni-turbo.
+   * Returns the transcript string, or null on failure.
+   */
+  private async transcribeAudio(base64Audio: string): Promise<string | null> {
+    const apiKey = process.env.DASHSCOPE_API_KEY;
+    if (!apiKey) {
+      console.warn('[feishu-adapter] DASHSCOPE_API_KEY not set, cannot transcribe audio');
+      return null;
+    }
+
+    try {
+      const body = JSON.stringify({
+        model: 'qwen-omni-turbo',
+        messages: [{
+          role: 'user',
+          content: [
+            {
+              type: 'input_audio',
+              input_audio: {
+                data: `data:audio/ogg;base64,${base64Audio}`,
+                format: 'ogg',
+              },
+            },
+            {
+              type: 'text',
+              text: '请将这段语音转录为文字，只输出转录文本，不要加任何解释、标点修正或格式。',
+            },
+          ],
+        }],
+        stream: false,
+      });
+
+      const res = await fetch('https://dashscope.aliyuncs.com/compatible-mode/v1/chat/completions', {
+        method: 'POST',
+        headers: {
+          'Authorization': `Bearer ${apiKey}`,
+          'Content-Type': 'application/json',
+        },
+        body,
+      });
+
+      if (!res.ok) {
+        console.error(`[feishu-adapter] STT API error: ${res.status} ${res.statusText}`);
+        return null;
+      }
+
+      const data = await res.json() as {
+        choices?: Array<{ message?: { content?: string } }>;
+      };
+      const transcript = data.choices?.[0]?.message?.content?.trim();
+      return transcript || null;
+    } catch (err) {
+      console.error(
+        '[feishu-adapter] STT transcription failed:',
+        err instanceof Error ? err.message : err,
+      );
+      return null;
+    }
   }
 
   // ── Resource download ───────────────────────────────────────

--- a/src/lib/bridge/adapters/feishu-adapter.ts
+++ b/src/lib/bridge/adapters/feishu-adapter.ts
@@ -21,12 +21,14 @@ import path from 'path';
 import * as lark from '@larksuiteoapi/node-sdk';
 import type {
   ChannelType,
+  FeishuBotConfig,
   InboundMessage,
   OutboundMessage,
   SendResult,
 } from '../types.js';
 import type { FileAttachment } from '../types.js';
 import type { ToolCallInfo } from '../types.js';
+import type { BridgeStore } from '../host.js';
 import { BaseChannelAdapter, registerAdapterFactory } from '../channel-adapter.js';
 import { getBridgeContext } from '../context.js';
 import {
@@ -121,6 +123,8 @@ const MIME_BY_TYPE: Record<string, string> = {
 export class FeishuAdapter extends BaseChannelAdapter {
   readonly channelType: ChannelType = 'feishu';
 
+  private readonly config: FeishuBotConfig;
+  public readonly botStore: BridgeStore;
   private running = false;
   private queue: InboundMessage[] = [];
   private waiters: Array<(msg: InboundMessage | null) => void> = [];
@@ -139,6 +143,20 @@ export class FeishuAdapter extends BaseChannelAdapter {
   /** In-flight card creation promises per chatId — prevents duplicate creation. */
   private cardCreatePromises = new Map<string, Promise<boolean>>();
 
+  constructor(config: FeishuBotConfig, botStore: BridgeStore) {
+    super();
+    this.config = config;
+    this.botStore = botStore;
+  }
+
+  get instanceKey(): string {
+    return `feishu:${this.config.name}`;
+  }
+
+  private get logPrefix(): string {
+    return `[${this.instanceKey}]`;
+  }
+
   // ── Lifecycle ───────────────────────────────────────────────
 
   async start(): Promise<void> {
@@ -146,14 +164,13 @@ export class FeishuAdapter extends BaseChannelAdapter {
 
     const configError = this.validateConfig();
     if (configError) {
-      console.warn('[feishu-adapter] Cannot start:', configError);
+      console.warn(this.logPrefix, 'Cannot start:', configError);
       return;
     }
 
-    const appId = getBridgeContext().store.getSetting('bridge_feishu_app_id') || '';
-    const appSecret = getBridgeContext().store.getSetting('bridge_feishu_app_secret') || '';
-    const domainSetting = getBridgeContext().store.getSetting('bridge_feishu_domain') || 'feishu';
-    const domain = domainSetting === 'lark'
+    const appId = this.config.appId;
+    const appSecret = this.config.appSecret;
+    const domain = this.config.domain === 'lark'
       ? lark.Domain.Lark
       : lark.Domain.Feishu;
 
@@ -195,7 +212,7 @@ export class FeishuAdapter extends BaseChannelAdapter {
       wsClientAny.handleEventData = (data: any) => {
         const msgType = data.headers?.find?.((h: any) => h.key === 'type')?.value;
         if (msgType === 'card') {
-          console.log('[feishu-adapter] handleEventData type: card (patched → event)');
+          console.log(this.logPrefix, 'handleEventData type: card (patched → event)');
           const patchedData = {
             ...data,
             headers: data.headers.map((h: any) =>
@@ -210,7 +227,7 @@ export class FeishuAdapter extends BaseChannelAdapter {
 
     this.wsClient.start({ eventDispatcher: dispatcher });
 
-    console.log('[feishu-adapter] Started (botOpenId:', this.botOpenId || 'unknown', ')');
+    console.log(this.logPrefix, 'Started (botOpenId:', this.botOpenId || 'unknown', ')');
   }
 
   async stop(): Promise<void> {
@@ -222,7 +239,7 @@ export class FeishuAdapter extends BaseChannelAdapter {
       try {
         this.wsClient.close({ force: true });
       } catch (err) {
-        console.warn('[feishu-adapter] WSClient close error:', err instanceof Error ? err.message : err);
+        console.warn(this.logPrefix, 'WSClient close error:', err instanceof Error ? err.message : err);
       }
       this.wsClient = null;
     }
@@ -246,7 +263,7 @@ export class FeishuAdapter extends BaseChannelAdapter {
     this.lastIncomingMessageId.clear();
     this.typingReactions.clear();
 
-    console.log('[feishu-adapter] Stopped');
+    console.log(this.logPrefix, 'Stopped');
   }
 
   isRunning(): boolean {
@@ -302,7 +319,7 @@ export class FeishuAdapter extends BaseChannelAdapter {
     }).catch((err) => {
       const code = (err as { code?: number })?.code;
       if (code !== 99991400 && code !== 99991403) {
-        console.warn('[feishu-adapter] Typing indicator failed:', err instanceof Error ? err.message : err);
+        console.warn(this.logPrefix, 'Typing indicator failed:', err instanceof Error ? err.message : err);
       }
     });
   }
@@ -352,6 +369,7 @@ export class FeishuAdapter extends BaseChannelAdapter {
         messageId: messageId || `card_action_${Date.now()}`,
         address: {
           channelType: 'feishu',
+          botName: this.config.name,
           chatId,
           userId,
         },
@@ -364,7 +382,7 @@ export class FeishuAdapter extends BaseChannelAdapter {
 
       return { toast: { type: 'info' as const, content: '已收到，正在处理...' } };
     } catch (err) {
-      console.error('[feishu-adapter] Card action handler error:', err instanceof Error ? err.message : err);
+      console.error(this.logPrefix, 'Card action handler error:', err instanceof Error ? err.message : err);
       return FALLBACK_TOAST;
     }
   }
@@ -416,7 +434,7 @@ export class FeishuAdapter extends BaseChannelAdapter {
       });
       const cardId = createResp?.data?.card_id;
       if (!cardId) {
-        console.warn('[feishu-adapter] Card create returned no card_id');
+        console.warn(this.logPrefix, 'Card create returned no card_id');
         return false;
       }
 
@@ -441,7 +459,7 @@ export class FeishuAdapter extends BaseChannelAdapter {
 
       const messageId = msgResp?.data?.message_id;
       if (!messageId) {
-        console.warn('[feishu-adapter] Card message send returned no message_id');
+        console.warn(this.logPrefix, 'Card message send returned no message_id');
         return false;
       }
 
@@ -458,10 +476,10 @@ export class FeishuAdapter extends BaseChannelAdapter {
         throttleTimer: null,
       });
 
-      console.log(`[feishu-adapter] Streaming card created: cardId=${cardId}, msgId=${messageId}`);
+      console.log(this.logPrefix, `Streaming card created: cardId=${cardId}, msgId=${messageId}`);
       return true;
     } catch (err) {
-      console.warn('[feishu-adapter] Failed to create streaming card:', err instanceof Error ? err.message : err);
+      console.warn(this.logPrefix, 'Failed to create streaming card:', err instanceof Error ? err.message : err);
       return false;
     }
   }
@@ -519,7 +537,7 @@ export class FeishuAdapter extends BaseChannelAdapter {
     }).then(() => {
       state.lastUpdateAt = Date.now();
     }).catch((err: unknown) => {
-      console.warn('[feishu-adapter] streamContent failed:', err instanceof Error ? err.message : err);
+      console.warn(this.logPrefix, 'streamContent failed:', err instanceof Error ? err.message : err);
     });
   }
 
@@ -585,10 +603,10 @@ export class FeishuAdapter extends BaseChannelAdapter {
         data: { card: { type: 'card_json', data: finalCardJson }, sequence: state.sequence },
       });
 
-      console.log(`[feishu-adapter] Card finalized: cardId=${state.cardId}, status=${status}, elapsed=${formatElapsed(elapsedMs)}`);
+      console.log(this.logPrefix, `Card finalized: cardId=${state.cardId}, status=${status}, elapsed=${formatElapsed(elapsedMs)}`);
       return true;
     } catch (err) {
-      console.warn('[feishu-adapter] Card finalize failed:', err instanceof Error ? err.message : err);
+      console.warn(this.logPrefix, 'Card finalize failed:', err instanceof Error ? err.message : err);
       return false;
     } finally {
       this.activeCards.delete(chatId);
@@ -688,7 +706,7 @@ export class FeishuAdapter extends BaseChannelAdapter {
     try {
       stat = fs.statSync(filePath);
     } catch {
-      console.warn(`[feishu-adapter] sendFile: file not found: ${filePath}`);
+      console.warn(this.logPrefix, `sendFile: file not found: ${filePath}`);
       return { ok: false, error: `File not found: ${filePath}` };
     }
 
@@ -706,7 +724,7 @@ export class FeishuAdapter extends BaseChannelAdapter {
    */
   private async uploadAndSendImage(chatId: string, filePath: string, fileSize: number): Promise<SendResult> {
     if (fileSize > MAX_IMAGE_UPLOAD_SIZE) {
-      console.warn(`[feishu-adapter] Image too large (${fileSize} bytes > ${MAX_IMAGE_UPLOAD_SIZE}): ${filePath}`);
+      console.warn(this.logPrefix, `Image too large (${fileSize} bytes > ${MAX_IMAGE_UPLOAD_SIZE}): ${filePath}`);
       return { ok: false, error: `Image exceeds 10MB limit` };
     }
 
@@ -721,7 +739,7 @@ export class FeishuAdapter extends BaseChannelAdapter {
 
       const imageKey = (uploadRes as any)?.image_key || (uploadRes as any)?.data?.image_key;
       if (!imageKey) {
-        console.warn('[feishu-adapter] Image upload returned no image_key:', uploadRes);
+        console.warn(this.logPrefix, 'Image upload returned no image_key:', uploadRes);
         return { ok: false, error: 'Image upload failed: no image_key returned' };
       }
 
@@ -736,12 +754,12 @@ export class FeishuAdapter extends BaseChannelAdapter {
       });
 
       if (sendRes?.data?.message_id) {
-        console.log(`[feishu-adapter] Image sent: ${filePath} → ${imageKey}`);
+        console.log(this.logPrefix, `Image sent: ${filePath} → ${imageKey}`);
         return { ok: true, messageId: sendRes.data.message_id };
       }
       return { ok: false, error: sendRes?.msg || 'Image send failed' };
     } catch (err) {
-      console.error('[feishu-adapter] Image upload/send error:', err instanceof Error ? err.message : err);
+      console.error(this.logPrefix, 'Image upload/send error:', err instanceof Error ? err.message : err);
       return { ok: false, error: err instanceof Error ? err.message : 'Image send failed' };
     }
   }
@@ -757,7 +775,7 @@ export class FeishuAdapter extends BaseChannelAdapter {
     fileSize: number,
   ): Promise<SendResult> {
     if (fileSize > MAX_FILE_UPLOAD_SIZE) {
-      console.warn(`[feishu-adapter] File too large (${fileSize} bytes > ${MAX_FILE_UPLOAD_SIZE}): ${filePath}`);
+      console.warn(this.logPrefix, `File too large (${fileSize} bytes > ${MAX_FILE_UPLOAD_SIZE}): ${filePath}`);
       return { ok: false, error: `File exceeds 30MB limit` };
     }
 
@@ -775,7 +793,7 @@ export class FeishuAdapter extends BaseChannelAdapter {
 
       const fileKey = (uploadRes as any)?.file_key || (uploadRes as any)?.data?.file_key;
       if (!fileKey) {
-        console.warn('[feishu-adapter] File upload returned no file_key:', uploadRes);
+        console.warn(this.logPrefix, 'File upload returned no file_key:', uploadRes);
         return { ok: false, error: 'File upload failed: no file_key returned' };
       }
 
@@ -790,12 +808,12 @@ export class FeishuAdapter extends BaseChannelAdapter {
       });
 
       if (sendRes?.data?.message_id) {
-        console.log(`[feishu-adapter] File sent: ${filePath} → ${fileKey}`);
+        console.log(this.logPrefix, `File sent: ${filePath} → ${fileKey}`);
         return { ok: true, messageId: sendRes.data.message_id };
       }
       return { ok: false, error: sendRes?.msg || 'File send failed' };
     } catch (err) {
-      console.error('[feishu-adapter] File upload/send error:', err instanceof Error ? err.message : err);
+      console.error(this.logPrefix, 'File upload/send error:', err instanceof Error ? err.message : err);
       return { ok: false, error: err instanceof Error ? err.message : 'File send failed' };
     }
   }
@@ -820,9 +838,9 @@ export class FeishuAdapter extends BaseChannelAdapter {
       if (res?.data?.message_id) {
         return { ok: true, messageId: res.data.message_id };
       }
-      console.warn('[feishu-adapter] Card send failed:', res?.msg, res?.code);
+      console.warn(this.logPrefix, 'Card send failed:', res?.msg, res?.code);
     } catch (err) {
-      console.warn('[feishu-adapter] Card send error, falling back to post:', err instanceof Error ? err.message : err);
+      console.warn(this.logPrefix, 'Card send error, falling back to post:', err instanceof Error ? err.message : err);
     }
 
     // Fallback to post
@@ -849,9 +867,9 @@ export class FeishuAdapter extends BaseChannelAdapter {
       if (res?.data?.message_id) {
         return { ok: true, messageId: res.data.message_id };
       }
-      console.warn('[feishu-adapter] Post send failed:', res?.msg, res?.code);
+      console.warn(this.logPrefix, 'Post send failed:', res?.msg, res?.code);
     } catch (err) {
-      console.warn('[feishu-adapter] Post send error, falling back to text:', err instanceof Error ? err.message : err);
+      console.warn(this.logPrefix, 'Post send error, falling back to text:', err instanceof Error ? err.message : err);
     }
 
     // Final fallback: plain text
@@ -924,9 +942,9 @@ export class FeishuAdapter extends BaseChannelAdapter {
         if (res?.data?.message_id) {
           return { ok: true, messageId: res.data.message_id };
         }
-        console.warn('[feishu-adapter] Permission button card send failed:', JSON.stringify({ code: (res as any)?.code, msg: res?.msg }));
+        console.warn(this.logPrefix, 'Permission button card send failed:', JSON.stringify({ code: (res as any)?.code, msg: res?.msg }));
       } catch (err) {
-        console.warn('[feishu-adapter] Permission button card error, falling back to text:', err instanceof Error ? err.message : err);
+        console.warn(this.logPrefix, 'Permission button card error, falling back to text:', err instanceof Error ? err.message : err);
       }
     }
 
@@ -980,9 +998,9 @@ export class FeishuAdapter extends BaseChannelAdapter {
       if (res?.data?.message_id) {
         return { ok: true, messageId: res.data.message_id };
       }
-      console.warn('[feishu-adapter] Fallback card also failed:', res?.msg);
+      console.warn(this.logPrefix, 'Fallback card also failed:', res?.msg);
     } catch (err) {
-      console.warn('[feishu-adapter] Fallback card error, sending plain text:', err instanceof Error ? err.message : err);
+      console.warn(this.logPrefix, 'Fallback card error, sending plain text:', err instanceof Error ? err.message : err);
     }
 
     // Last resort: plain text message (works even without card permissions)
@@ -1016,33 +1034,35 @@ export class FeishuAdapter extends BaseChannelAdapter {
   // ── Config & Auth ───────────────────────────────────────────
 
   validateConfig(): string | null {
-    const enabled = getBridgeContext().store.getSetting('bridge_feishu_enabled');
-    if (enabled !== 'true') return 'bridge_feishu_enabled is not true';
-
-    const appId = getBridgeContext().store.getSetting('bridge_feishu_app_id');
-    if (!appId) return 'bridge_feishu_app_id not configured';
-
-    const appSecret = getBridgeContext().store.getSetting('bridge_feishu_app_secret');
-    if (!appSecret) return 'bridge_feishu_app_secret not configured';
+    if (!this.config.appId) return `${this.logPrefix} appId not configured`;
+    if (!this.config.appSecret) return `${this.logPrefix} appSecret not configured`;
 
     return null;
   }
 
   isAuthorized(userId: string, chatId: string): boolean {
-    const allowedUsers = getBridgeContext().store.getSetting('bridge_feishu_allowed_users') || '';
-    if (!allowedUsers) {
+    const allowedUsers = this.config.allowedUsers;
+    if (!allowedUsers || allowedUsers.length === 0) {
       // No restriction configured — allow all
       return true;
     }
 
     const allowed = allowedUsers
-      .split(',')
       .map((s) => s.trim())
       .filter(Boolean);
 
     if (allowed.length === 0) return true;
 
     return allowed.includes(userId) || allowed.includes(chatId);
+  }
+
+  resolveWorkingDirectory(userId?: string): string {
+    if (userId) {
+      const userOverride = this.config.userOverrides?.get(userId);
+      if (userOverride?.workingDirectory) return userOverride.workingDirectory;
+    }
+    if (this.config.workingDirectory) return this.config.workingDirectory;
+    return getBridgeContext().store.getSetting('bridge_default_work_dir') || process.cwd();
   }
 
   // ── Incoming event handler ──────────────────────────────────
@@ -1052,7 +1072,8 @@ export class FeishuAdapter extends BaseChannelAdapter {
       await this.processIncomingEvent(data);
     } catch (err) {
       console.error(
-        '[feishu-adapter] Unhandled error in event handler:',
+        this.logPrefix,
+        'Unhandled error in event handler:',
         err instanceof Error ? err.stack || err.message : err,
       );
     }
@@ -1079,42 +1100,32 @@ export class FeishuAdapter extends BaseChannelAdapter {
 
     // Authorization check
     if (!this.isAuthorized(userId, chatId)) {
-      console.warn('[feishu-adapter] Unauthorized message from userId:', userId, 'chatId:', chatId);
+      console.warn(this.logPrefix, 'Unauthorized message from userId:', userId, 'chatId:', chatId);
       return;
     }
 
     // Group chat policy
     if (isGroup) {
-      const policy = getBridgeContext().store.getSetting('bridge_feishu_group_policy') || 'open';
+      const policy = this.config.groupPolicy || 'open';
 
       if (policy === 'disabled') {
-        console.log('[feishu-adapter] Group message ignored (policy=disabled), chatId:', chatId);
+        console.log(this.logPrefix, 'Group message ignored (policy=disabled), chatId:', chatId);
         return;
       }
 
       if (policy === 'allowlist') {
-        const allowedGroups = (getBridgeContext().store.getSetting('bridge_feishu_group_allow_from') || '')
-          .split(',')
-          .map((s) => s.trim())
-          .filter(Boolean);
+        const allowedGroups = this.config.groupAllowFrom || [];
         if (!allowedGroups.includes(chatId)) {
-          console.log('[feishu-adapter] Group message ignored (not in allowlist), chatId:', chatId);
+          console.log(this.logPrefix, 'Group message ignored (not in allowlist), chatId:', chatId);
           return;
         }
       }
 
-      // Require @mention check (store setting > env var > default true)
-      const storeSetting = getBridgeContext().store.getSetting('bridge_feishu_require_mention');
-      const envSetting = process.env.CTI_FEISHU_REQUIRE_MENTION;
-      const requireMention = storeSetting !== null
-        ? storeSetting !== 'false'
-        : envSetting !== undefined
-          ? envSetting !== 'false'
-          : true;
+      const requireMention = this.config.requireMention ?? true;
       if (requireMention && !this.isBotMentioned(msg.mentions)) {
-        console.log('[feishu-adapter] Group message ignored (bot not @mentioned), chatId:', chatId, 'msgId:', msg.message_id);
+        console.log(this.logPrefix, 'Group message ignored (bot not @mentioned), chatId:', chatId, 'msgId:', msg.message_id);
         try {
-          getBridgeContext().store.insertAuditLog({
+          this.botStore.insertAuditLog({
             channelType: 'feishu',
             chatId,
             direction: 'inbound',
@@ -1138,9 +1149,9 @@ export class FeishuAdapter extends BaseChannelAdapter {
       text = this.parseTextContent(msg.content);
     } else if (messageType === 'image') {
       // [P1] Download image with failure fallback
-      console.log('[feishu-adapter] Image message received, content:', msg.content);
+      console.log(this.logPrefix, 'Image message received, content:', msg.content);
       const fileKey = this.extractFileKey(msg.content);
-      console.log('[feishu-adapter] Extracted fileKey:', fileKey);
+      console.log(this.logPrefix, 'Extracted fileKey:', fileKey);
       if (fileKey) {
         const attachment = await this.downloadResource(msg.message_id, fileKey, 'image');
         if (attachment) {
@@ -1148,7 +1159,7 @@ export class FeishuAdapter extends BaseChannelAdapter {
         } else {
           text = '[image download failed]';
           try {
-            getBridgeContext().store.insertAuditLog({
+            this.botStore.insertAuditLog({
               channelType: 'feishu',
               chatId,
               direction: 'inbound',
@@ -1167,16 +1178,16 @@ export class FeishuAdapter extends BaseChannelAdapter {
           const transcript = await this.transcribeAudio(attachment.data);
           if (transcript) {
             text = transcript;
-            console.log(`[feishu-adapter] Voice STT success (${transcript.length} chars): ${transcript.slice(0, 80)}`);
+            console.log(this.logPrefix, `Voice STT success (${transcript.length} chars): ${transcript.slice(0, 80)}`);
           } else {
             // STT failed, fall back to attaching audio file
             attachments.push(attachment);
-            console.warn('[feishu-adapter] Voice STT failed, falling back to audio attachment');
+            console.warn(this.logPrefix, 'Voice STT failed, falling back to audio attachment');
           }
         } else {
           text = '[audio download failed]';
           try {
-            getBridgeContext().store.insertAuditLog({
+            this.botStore.insertAuditLog({
               channelType: 'feishu',
               chatId,
               direction: 'inbound',
@@ -1199,7 +1210,7 @@ export class FeishuAdapter extends BaseChannelAdapter {
         } else {
           text = `[${messageType} download failed]`;
           try {
-            getBridgeContext().store.insertAuditLog({
+            this.botStore.insertAuditLog({
               channelType: 'feishu',
               chatId,
               direction: 'inbound',
@@ -1222,7 +1233,7 @@ export class FeishuAdapter extends BaseChannelAdapter {
       }
     } else {
       // Unsupported type — log and skip
-      console.log(`[feishu-adapter] Unsupported message type: ${messageType}, msgId: ${msg.message_id}`);
+      console.log(this.logPrefix, `Unsupported message type: ${messageType}, msgId: ${msg.message_id}`);
       return;
     }
 
@@ -1234,6 +1245,7 @@ export class FeishuAdapter extends BaseChannelAdapter {
     const timestamp = parseInt(msg.create_time, 10) || Date.now();
     const address = {
       channelType: 'feishu' as const,
+      botName: this.config.name,
       chatId,
       userId,
     };
@@ -1273,7 +1285,7 @@ export class FeishuAdapter extends BaseChannelAdapter {
       const summary = attachments.length > 0
         ? `[${attachments.length} attachment(s)] ${text.slice(0, 150)}`
         : text.slice(0, 200);
-      getBridgeContext().store.insertAuditLog({
+      this.botStore.insertAuditLog({
         channelType: 'feishu',
         chatId,
         direction: 'inbound',
@@ -1373,7 +1385,7 @@ export class FeishuAdapter extends BaseChannelAdapter {
       });
       const tokenData: any = await tokenRes.json();
       if (!tokenData.tenant_access_token) {
-        console.warn('[feishu-adapter] Failed to get tenant access token');
+        console.warn(this.logPrefix, 'Failed to get tenant access token');
         return;
       }
 
@@ -1392,11 +1404,12 @@ export class FeishuAdapter extends BaseChannelAdapter {
         this.botIds.add(botData.bot.bot_id);
       }
       if (!this.botOpenId) {
-        console.warn('[feishu-adapter] Could not resolve bot open_id');
+        console.warn(this.logPrefix, 'Could not resolve bot open_id');
       }
     } catch (err) {
       console.warn(
-        '[feishu-adapter] Failed to resolve bot identity:',
+        this.logPrefix,
+        'Failed to resolve bot identity:',
         err instanceof Error ? err.message : err,
       );
     }
@@ -1425,19 +1438,19 @@ export class FeishuAdapter extends BaseChannelAdapter {
   // ── Voice STT (Speech-to-Text) ──────────────────────────────
 
   /**
-   * Transcribe audio (base64-encoded) to text via DashScope qwen-omni-turbo.
+   * Transcribe audio (base64-encoded) to text via DashScope qwen3-asr-flash.
    * Returns the transcript string, or null on failure.
    */
   private async transcribeAudio(base64Audio: string): Promise<string | null> {
-    const apiKey = process.env.DASHSCOPE_API_KEY;
+    const apiKey = process.env.DASHSCOPE_STT_API_KEY || process.env.DASHSCOPE_API_KEY;
     if (!apiKey) {
-      console.warn('[feishu-adapter] DASHSCOPE_API_KEY not set, cannot transcribe audio');
+      console.warn(this.logPrefix, 'DASHSCOPE_STT_API_KEY not set, cannot transcribe audio');
       return null;
     }
 
     try {
       const body = JSON.stringify({
-        model: 'qwen-omni-turbo',
+        model: 'qwen3-asr-flash',
         messages: [{
           role: 'user',
           content: [
@@ -1447,10 +1460,6 @@ export class FeishuAdapter extends BaseChannelAdapter {
                 data: `data:audio/ogg;base64,${base64Audio}`,
                 format: 'ogg',
               },
-            },
-            {
-              type: 'text',
-              text: '请将这段语音转录为文字，只输出转录文本，不要加任何解释、标点修正或格式。',
             },
           ],
         }],
@@ -1467,7 +1476,7 @@ export class FeishuAdapter extends BaseChannelAdapter {
       });
 
       if (!res.ok) {
-        console.error(`[feishu-adapter] STT API error: ${res.status} ${res.statusText}`);
+        console.error(this.logPrefix, `STT API error: ${res.status} ${res.statusText}`);
         return null;
       }
 
@@ -1478,7 +1487,8 @@ export class FeishuAdapter extends BaseChannelAdapter {
       return transcript || null;
     } catch (err) {
       console.error(
-        '[feishu-adapter] STT transcription failed:',
+        this.logPrefix,
+        'STT transcription failed:',
         err instanceof Error ? err.message : err,
       );
       return null;
@@ -1499,7 +1509,7 @@ export class FeishuAdapter extends BaseChannelAdapter {
     if (!this.restClient) return null;
 
     try {
-      console.log(`[feishu-adapter] Downloading resource: type=${resourceType}, key=${fileKey}, msgId=${messageId}`);
+      console.log(this.logPrefix, `Downloading resource: type=${resourceType}, key=${fileKey}, msgId=${messageId}`);
 
       const res = await this.restClient.im.messageResource.get({
         path: {
@@ -1512,7 +1522,7 @@ export class FeishuAdapter extends BaseChannelAdapter {
       });
 
       if (!res) {
-        console.warn('[feishu-adapter] messageResource.get returned null/undefined');
+        console.warn(this.logPrefix, 'messageResource.get returned null/undefined');
         return null;
       }
 
@@ -1529,7 +1539,7 @@ export class FeishuAdapter extends BaseChannelAdapter {
           const buf = Buffer.isBuffer(chunk) ? chunk : Buffer.from(chunk);
           totalSize += buf.length;
           if (totalSize > MAX_FILE_SIZE) {
-            console.warn(`[feishu-adapter] Resource too large (>${MAX_FILE_SIZE} bytes), key: ${fileKey}`);
+            console.warn(this.logPrefix, `Resource too large (>${MAX_FILE_SIZE} bytes), key: ${fileKey}`);
             return null;
           }
           chunks.push(buf);
@@ -1537,7 +1547,7 @@ export class FeishuAdapter extends BaseChannelAdapter {
         buffer = Buffer.concat(chunks);
       } catch (streamErr) {
         // Stream approach failed — fall back to writeFile + read
-        console.warn('[feishu-adapter] Stream read failed, falling back to writeFile:', streamErr instanceof Error ? streamErr.message : streamErr);
+        console.warn(this.logPrefix, 'Stream read failed, falling back to writeFile:', streamErr instanceof Error ? streamErr.message : streamErr);
 
         const fs = await import('fs');
         const os = await import('os');
@@ -1547,7 +1557,7 @@ export class FeishuAdapter extends BaseChannelAdapter {
           await res.writeFile(tmpPath);
           buffer = fs.readFileSync(tmpPath);
           if (buffer.length > MAX_FILE_SIZE) {
-            console.warn(`[feishu-adapter] Resource too large (>${MAX_FILE_SIZE} bytes), key: ${fileKey}`);
+            console.warn(this.logPrefix, `Resource too large (>${MAX_FILE_SIZE} bytes), key: ${fileKey}`);
             return null;
           }
         } finally {
@@ -1556,7 +1566,7 @@ export class FeishuAdapter extends BaseChannelAdapter {
       }
 
       if (!buffer || buffer.length === 0) {
-        console.warn('[feishu-adapter] Downloaded resource is empty, key:', fileKey);
+        console.warn(this.logPrefix, 'Downloaded resource is empty, key:', fileKey);
         return null;
       }
 
@@ -1568,7 +1578,7 @@ export class FeishuAdapter extends BaseChannelAdapter {
         : resourceType === 'video' ? 'mp4'
         : 'bin';
 
-      console.log(`[feishu-adapter] Resource downloaded: ${buffer.length} bytes, key=${fileKey}`);
+      console.log(this.logPrefix, `Resource downloaded: ${buffer.length} bytes, key=${fileKey}`);
 
       return {
         id,
@@ -1579,7 +1589,8 @@ export class FeishuAdapter extends BaseChannelAdapter {
       };
     } catch (err) {
       console.error(
-        `[feishu-adapter] Resource download failed (type=${resourceType}, key=${fileKey}):`,
+        this.logPrefix,
+        `Resource download failed (type=${resourceType}, key=${fileKey}):`,
         err instanceof Error ? err.stack || err.message : err,
       );
       return null;
@@ -1605,4 +1616,9 @@ export class FeishuAdapter extends BaseChannelAdapter {
 }
 
 // Self-register so bridge-manager can create FeishuAdapter via the registry.
-registerAdapterFactory('feishu', () => new FeishuAdapter());
+registerAdapterFactory('feishu', (config?: unknown, store?: BridgeStore) => {
+  if (!config || !store) {
+    throw new Error('FeishuAdapter requires FeishuBotConfig and BridgeStore');
+  }
+  return new FeishuAdapter(config as FeishuBotConfig, store);
+});

--- a/src/lib/bridge/bridge-manager.ts
+++ b/src/lib/bridge/bridge-manager.ts
@@ -28,7 +28,7 @@ import {
   validateMode,
 } from './security/validators.js';
 import { readFileSync, existsSync, statSync, openSync, readSync, closeSync, fstatSync } from 'node:fs';
-import { join } from 'node:path';
+import { join, basename } from 'node:path';
 import { homedir } from 'node:os';
 
 // ── Session preview helpers ────────────────────────────────────
@@ -820,6 +820,35 @@ async function handleMessage(
         replyToMessageId: msg.messageId,
       };
       await deliver(adapter, errorResponse);
+    }
+
+    // ── Outbound file sending ──────────────────────────────────
+    // Send any files Claude created during this turn (images, documents).
+    if (result.createdFiles && result.createdFiles.length > 0 && adapter.sendFile) {
+      for (const filePath of result.createdFiles) {
+        try {
+          // Verify file still exists (Claude may have created then deleted it)
+          if (!existsSync(filePath)) {
+            console.log(`[bridge-manager] Skipping file (not found): ${filePath}`);
+            continue;
+          }
+          const fileName = basename(filePath);
+          const fileResult = await adapter.sendFile(msg.address.chatId, filePath, fileName);
+          if (fileResult.ok) {
+            store.insertAuditLog({
+              channelType: adapter.channelType,
+              chatId: msg.address.chatId,
+              direction: 'outbound',
+              messageId: fileResult.messageId || '',
+              summary: `[FILE] Sent: ${fileName}`,
+            });
+          } else {
+            console.warn(`[bridge-manager] Failed to send file ${fileName}:`, fileResult.error);
+          }
+        } catch (err) {
+          console.warn(`[bridge-manager] Error sending file ${filePath}:`, err instanceof Error ? err.message : err);
+        }
+      }
     }
 
     // Persist the actual SDK session ID for future resume.

--- a/src/lib/bridge/bridge-manager.ts
+++ b/src/lib/bridge/bridge-manager.ts
@@ -27,6 +27,91 @@ import {
   sanitizeInput,
   validateMode,
 } from './security/validators.js';
+import { readFileSync, existsSync, statSync, openSync, readSync, closeSync, fstatSync } from 'node:fs';
+import { join } from 'node:path';
+import { homedir } from 'node:os';
+
+// ── Session preview helpers ────────────────────────────────────
+
+/**
+ * Clean raw message text for single-line preview display.
+ * Strips markdown formatting, HTML/XML tags, collapses whitespace.
+ */
+function cleanPreviewText(raw: string, maxLen: number): string {
+  let t = raw;
+  // Strip [sender: ...] prefix (claude-to-im injects this)
+  t = t.replace(/^\[sender:\s*[^\]]*\]\s*/, '');
+  // Strip HTML/XML tags
+  t = t.replace(/<[^>]*>/g, '');
+  // Strip markdown: bold, italic, headers, links, images
+  t = t.replace(/\*\*([^*]*)\*\*/g, '$1');
+  t = t.replace(/\*([^*]*)\*/g, '$1');
+  t = t.replace(/`{1,3}[^`]*`{1,3}/g, '');
+  t = t.replace(/^#{1,6}\s+/gm, '');
+  t = t.replace(/\[([^\]]*)\]\([^)]*\)/g, '$1');
+  t = t.replace(/!\[([^\]]*)\]\([^)]*\)/g, '');
+  // Strip list prefixes and table pipes
+  t = t.replace(/^\s*[-*+]\s+/gm, '');
+  t = t.replace(/^\s*\d+\.\s+/gm, '');
+  t = t.replace(/\|/g, ' ');
+  // Collapse to single line
+  t = t.replace(/\n+/g, ' ').replace(/\s+/g, ' ').trim();
+  if (!t) return '';
+  if (t.length > maxLen) t = t.slice(0, maxLen) + '\u2026';
+  return t;
+}
+
+/**
+ * Extract the last meaningful text from JSONL lines (searched in reverse).
+ * Accepts both user and assistant messages.
+ */
+function extractLastText(jsonLines: string[], maxLen: number): string {
+  for (let i = jsonLines.length - 1; i >= 0; i--) {
+    try {
+      const obj = JSON.parse(jsonLines[i]);
+      if ((obj.type === 'user' || obj.type === 'assistant') && obj.message?.role) {
+        const content = obj.message.content;
+        let raw = '';
+        if (typeof content === 'string') raw = content;
+        else if (Array.isArray(content)) {
+          for (const block of content) {
+            if (block?.type === 'text' && block.text) { raw = block.text; break; }
+          }
+        }
+        if (!raw) continue;
+        // Skip system/meta content
+        const firstLine = raw.split('\n')[0].trim();
+        if (/^\/(clear|compact|help|init|sessions|switch)/.test(firstLine)) continue;
+        if (/^\[.*\d{4}-\d{2}-\d{2}/.test(firstLine) || /^\[.*GMT/.test(firstLine)) continue;
+        if (/^Caveat:|^<system-reminder>|^<command-|^<local-command/.test(firstLine)) continue;
+        const cleaned = cleanPreviewText(raw, maxLen);
+        if (cleaned) return cleaned;
+      }
+    } catch { continue; }
+  }
+  return '';
+}
+
+/**
+ * Get a preview of the last message in a Claude Code session.
+ * Reads the tail of the session's JSONL file for performance.
+ */
+function getSessionPreview(sdkSessionId: string, workdir: string, maxLen = 45): string {
+  if (!sdkSessionId) return '';
+  try {
+    const projectDir = (workdir || '~').replace(/[^a-zA-Z0-9.]/g, '-');
+    const jsonlPath = join(homedir(), '.claude', 'projects', projectDir, `${sdkSessionId}.jsonl`);
+    if (!existsSync(jsonlPath)) return '';
+    const fd = openSync(jsonlPath, 'r');
+    const size = fstatSync(fd).size;
+    const tailSize = Math.min(size, 65536);
+    const buf = Buffer.alloc(tailSize);
+    readSync(fd, buf, 0, tailSize, Math.max(0, size - tailSize));
+    closeSync(fd);
+    const lines = buf.toString('utf-8').trimEnd().split('\n');
+    return extractLastText(lines, maxLen);
+  } catch { return ''; }
+}
 
 const GLOBAL_KEY = '__bridge_manager__';
 
@@ -917,10 +1002,23 @@ async function handleCommand(
       if (bindings.length === 0) {
         response = 'No sessions found.';
       } else {
+        const currentBinding = router.resolve(msg.address);
+        // Sort by most recently active first
+        const sorted = bindings.slice().sort((a, b) => {
+          const ta = a.updatedAt || a.createdAt || '';
+          const tb = b.updatedAt || b.createdAt || '';
+          return tb.localeCompare(ta);
+        });
         const lines = ['<b>Sessions:</b>', ''];
-        for (const b of bindings.slice(0, 10)) {
-          const active = b.active ? 'active' : 'inactive';
-          lines.push(`<code>${b.codepilotSessionId.slice(0, 8)}...</code> [${active}] ${escapeHtml(b.workingDirectory || '~')}`);
+        const shown = sorted.slice(0, 15);
+        for (let i = 0; i < shown.length; i++) {
+          const b = shown[i];
+          const isCurrent = currentBinding && b.codepilotSessionId === currentBinding.codepilotSessionId;
+          const marker = isCurrent ? ' \u25C0' : '';
+          const id = (b.sdkSessionId || b.codepilotSessionId).slice(0, 8);
+          const preview = getSessionPreview(b.sdkSessionId, b.workingDirectory);
+          const previewLine = preview ? `\n    \uD83D\uDCAC ${escapeHtml(preview)}` : '';
+          lines.push(`<b>${i + 1}.</b> <code>${id}</code>${marker}${previewLine}`);
         }
         response = lines.join('\n');
       }

--- a/src/lib/bridge/bridge-manager.ts
+++ b/src/lib/bridge/bridge-manager.ts
@@ -10,6 +10,7 @@
 import type { BridgeStatus, InboundMessage, OutboundMessage, StreamingPreviewState, ToolCallInfo } from './types.js';
 import { createAdapter, getRegisteredTypes } from './channel-adapter.js';
 import type { BaseChannelAdapter } from './channel-adapter.js';
+import type { BridgeStore } from './host.js';
 // Side-effect import: triggers self-registration of all adapter factories
 import './adapters/index.js';
 import * as router from './channel-router.js';
@@ -134,8 +135,11 @@ const STREAM_DEFAULTS: Record<string, StreamConfig> = {
   discord: { intervalMs: 1500, minDeltaChars: 40, maxChars: 1900 },
 };
 
-function getStreamConfig(channelType = 'telegram'): StreamConfig {
-  const { store } = getBridgeContext();
+function getAdapterStore(adapter: BaseChannelAdapter): BridgeStore {
+  return (adapter as BaseChannelAdapter & { botStore?: BridgeStore }).botStore || getBridgeContext().store;
+}
+
+function getStreamConfig(channelType = 'telegram', store = getBridgeContext().store): StreamConfig {
   const defaults = STREAM_DEFAULTS[channelType] || STREAM_DEFAULTS.telegram;
   const prefix = `bridge_${channelType}_stream_`;
   const intervalMs = parseInt(store.getSetting(`${prefix}interval_ms`) || '', 10) || defaults.intervalMs;
@@ -153,11 +157,15 @@ function getStreamConfig(channelType = 'telegram'): StreamConfig {
  * waiting for the permission to be resolved, so putting "1" behind the
  * session lock would deadlock.
  */
-function isNumericPermissionShortcut(channelType: string, rawText: string, chatId: string): boolean {
+function isNumericPermissionShortcut(
+  channelType: string,
+  rawText: string,
+  chatId: string,
+  store: BridgeStore,
+): boolean {
   if (channelType !== 'feishu' && channelType !== 'qq' && channelType !== 'weixin') return false;
   const normalized = rawText.normalize('NFKC').replace(/[\u200B-\u200D\uFEFF]/g, '').trim();
   if (!/^[123]$/.test(normalized)) return false;
-  const { store } = getBridgeContext();
   const pending = store.listPendingPermissionLinksByChat(chatId);
   return pending.length > 0; // any pending → route to inline path
 }
@@ -200,11 +208,12 @@ async function deliverResponse(
   responseText: string,
   sessionId: string,
   replyToMessageId?: string,
+  store?: BridgeStore,
 ): Promise<SendResult> {
   if (adapter.channelType === 'telegram') {
     const chunks = markdownToTelegramChunks(responseText, 4096);
     if (chunks.length > 0) {
-      return deliverRendered(adapter, address, chunks, { sessionId, replyToMessageId });
+      return deliverRendered(adapter, address, chunks, { sessionId, replyToMessageId, store });
     }
     return { ok: true };
   }
@@ -217,7 +226,7 @@ async function deliverResponse(
         text: chunks[i].text,
         parseMode: 'Markdown',
         replyToMessageId,
-      }, { sessionId });
+      }, { sessionId, store });
       if (!result.ok) return result;
     }
     return { ok: true };
@@ -229,7 +238,7 @@ async function deliverResponse(
       text: responseText,
       parseMode: 'Markdown',
       replyToMessageId,
-    }, { sessionId });
+    }, { sessionId, store });
   }
   // Generic fallback: deliver as plain text (deliver() handles chunking internally)
   return deliver(adapter, {
@@ -237,7 +246,7 @@ async function deliverResponse(
     text: responseText,
     parseMode: 'plain',
     replyToMessageId,
-  }, { sessionId });
+  }, { sessionId, store });
 }
 
 interface AdapterMeta {
@@ -282,10 +291,31 @@ function getState(): BridgeManagerState {
  * Process a function with per-session serialization.
  * Different sessions run concurrently; same-session requests are serialized.
  */
+// Session lock timeout: release the lock if a single message takes too long,
+// so subsequent messages aren't blocked. Should exceed CC_MAX_TIMEOUT (10 min)
+// to let the CC-level abort fire first. Default 12 min.
+const SESSION_LOCK_TIMEOUT_MS = parseInt(process.env.CTI_SESSION_LOCK_TIMEOUT_MS || '', 10) || 720_000;
+
 function processWithSessionLock(sessionId: string, fn: () => Promise<void>): Promise<void> {
   const state = getState();
   const prev = state.sessionLocks.get(sessionId) || Promise.resolve();
-  const current = prev.then(fn, fn);
+
+  const timedFn = (): Promise<void> => {
+    const work = fn();
+    let timer: ReturnType<typeof setTimeout>;
+    const timeout = new Promise<void>((resolve) => {
+      timer = setTimeout(() => {
+        console.warn(
+          `[bridge-manager] Session lock timeout for ${sessionId.slice(0, 8)}: ` +
+          `releasing after ${SESSION_LOCK_TIMEOUT_MS / 1000}s`,
+        );
+        resolve();
+      }, SESSION_LOCK_TIMEOUT_MS);
+    });
+    return Promise.race([work, timeout]).finally(() => clearTimeout(timer!));
+  };
+
+  const current = prev.then(timedFn, timedFn);
   state.sessionLocks.set(sessionId, current);
   // Cleanup when the chain completes.
   // Suppress rejection on the cleanup chain — callers handle errors on `current` directly.
@@ -301,11 +331,12 @@ function processWithSessionLock(sessionId: string, fn: () => Promise<void>): Pro
  * Start the bridge system.
  * Checks feature flags, registers enabled adapters, starts polling loops.
  */
-export async function start(): Promise<void> {
+export async function start(opts?: { botStores?: Map<string, BridgeStore> }): Promise<void> {
   const state = getState();
   if (state.running) return;
 
-  const { store, lifecycle } = getBridgeContext();
+  const { store, lifecycle, feishuBotConfigs = [], botStores } = getBridgeContext();
+  const effectiveBotStores = opts?.botStores || botStores;
 
   const bridgeEnabled = store.getSetting('remote_bridge_enabled') === 'true';
   if (!bridgeEnabled) {
@@ -318,6 +349,22 @@ export async function start(): Promise<void> {
     const settingKey = `bridge_${channelType}_enabled`;
     if (store.getSetting(settingKey) !== 'true') continue;
 
+    if (channelType === 'feishu') {
+      for (const botConfig of feishuBotConfigs) {
+        const botStore = effectiveBotStores?.get(botConfig.name);
+        if (!botStore) throw new Error(`No store for feishu bot: ${botConfig.name}`);
+
+        const adapter = createAdapter('feishu', botConfig, botStore);
+        const configError = adapter.validateConfig();
+        if (!configError) {
+          registerAdapter(adapter);
+        } else {
+          console.warn(`[bridge-manager] ${adapter.instanceKey} adapter not valid:`, configError);
+        }
+      }
+      continue;
+    }
+
     const adapter = createAdapter(channelType);
     if (!adapter) continue;
 
@@ -325,7 +372,7 @@ export async function start(): Promise<void> {
     if (!configError) {
       registerAdapter(adapter);
     } else {
-      console.warn(`[bridge-manager] ${channelType} adapter not valid:`, configError);
+      console.warn(`[bridge-manager] ${adapter.instanceKey} adapter not valid:`, configError);
     }
   }
 
@@ -432,9 +479,10 @@ export function getStatus(): BridgeStatus {
   return {
     running: state.running,
     startedAt: state.startedAt,
-    adapters: Array.from(state.adapters.entries()).map(([type, adapter]) => {
-      const meta = state.adapterMeta.get(type);
+    adapters: Array.from(state.adapters.entries()).map(([instanceKey, adapter]) => {
+      const meta = state.adapterMeta.get(instanceKey);
       return {
+        instanceKey,
         channelType: adapter.channelType,
         running: adapter.isRunning(),
         connectedAt: state.startedAt,
@@ -450,7 +498,25 @@ export function getStatus(): BridgeStatus {
  */
 export function registerAdapter(adapter: BaseChannelAdapter): void {
   const state = getState();
-  state.adapters.set(adapter.channelType, adapter);
+  state.adapters.set(adapter.instanceKey, adapter);
+}
+
+/**
+ * Look up a registered adapter by instance key.
+ */
+export function getAdapter(instanceKey: string): BaseChannelAdapter | undefined {
+  return getState().adapters.get(instanceKey);
+}
+
+/**
+ * Unregister a channel adapter by instance key.
+ */
+export function unregisterAdapter(instanceKey: string): void {
+  const state = getState();
+  state.adapters.delete(instanceKey);
+  state.adapterMeta.delete(instanceKey);
+  state.loopAborts.get(instanceKey)?.abort();
+  state.loopAborts.delete(instanceKey);
 }
 
 /**
@@ -460,8 +526,10 @@ export function registerAdapter(adapter: BaseChannelAdapter): void {
  */
 function runAdapterLoop(adapter: BaseChannelAdapter): void {
   const state = getState();
+  const instanceKey = adapter.instanceKey;
+  const store = getAdapterStore(adapter);
   const abort = new AbortController();
-  state.loopAborts.set(adapter.channelType, abort);
+  state.loopAborts.set(instanceKey, abort);
 
   (async () => {
     while (state.running && adapter.isRunning()) {
@@ -480,11 +548,11 @@ function runAdapterLoop(adapter: BaseChannelAdapter): void {
         if (
           msg.callbackData ||
           msg.text.trim().startsWith('/') ||
-          isNumericPermissionShortcut(adapter.channelType, msg.text.trim(), msg.address.chatId)
+          isNumericPermissionShortcut(adapter.channelType, msg.text.trim(), msg.address.chatId, store)
         ) {
           await handleMessage(adapter, msg);
         } else {
-          const binding = router.resolve(msg.address);
+          const binding = router.resolve(msg.address, { store });
           // Fire-and-forget into session lock — loop continues to accept
           // messages for other sessions immediately.
           processWithSessionLock(binding.codepilotSessionId, () =>
@@ -496,11 +564,11 @@ function runAdapterLoop(adapter: BaseChannelAdapter): void {
       } catch (err) {
         if (abort.signal.aborted) break;
         const errMsg = err instanceof Error ? err.message : String(err);
-        console.error(`[bridge-manager] Error in ${adapter.channelType} loop:`, err);
+        console.error(`[bridge-manager] Error in ${instanceKey} loop:`, err);
         // Track last error per adapter
-        const meta = state.adapterMeta.get(adapter.channelType) || { lastMessageAt: null, lastError: null };
+        const meta = state.adapterMeta.get(instanceKey) || { lastMessageAt: null, lastError: null };
         meta.lastError = errMsg;
-        state.adapterMeta.set(adapter.channelType, meta);
+        state.adapterMeta.set(instanceKey, meta);
         // Brief delay to prevent tight error loops
         await new Promise(r => setTimeout(r, 1000));
       }
@@ -508,10 +576,10 @@ function runAdapterLoop(adapter: BaseChannelAdapter): void {
   })().catch(err => {
     if (!abort.signal.aborted) {
       const errMsg = err instanceof Error ? err.message : String(err);
-      console.error(`[bridge-manager] ${adapter.channelType} loop crashed:`, err);
-      const meta = state.adapterMeta.get(adapter.channelType) || { lastMessageAt: null, lastError: null };
+      console.error(`[bridge-manager] ${instanceKey} loop crashed:`, err);
+      const meta = state.adapterMeta.get(instanceKey) || { lastMessageAt: null, lastError: null };
       meta.lastError = errMsg;
-      state.adapterMeta.set(adapter.channelType, meta);
+      state.adapterMeta.set(instanceKey, meta);
     }
   });
 }
@@ -523,13 +591,14 @@ async function handleMessage(
   adapter: BaseChannelAdapter,
   msg: InboundMessage,
 ): Promise<void> {
-  const { store } = getBridgeContext();
+  const store = getAdapterStore(adapter);
+  const instanceKey = adapter.instanceKey;
 
   // Update lastMessageAt for this adapter
   const adapterState = getState();
-  const meta = adapterState.adapterMeta.get(adapter.channelType) || { lastMessageAt: null, lastError: null };
+  const meta = adapterState.adapterMeta.get(instanceKey) || { lastMessageAt: null, lastError: null };
   meta.lastMessageAt = new Date().toISOString();
-  adapterState.adapterMeta.set(adapter.channelType, meta);
+  adapterState.adapterMeta.set(instanceKey, meta);
 
   // Acknowledge the update offset after processing completes (or fails).
   // This ensures the adapter only advances its committed offset once the
@@ -542,7 +611,7 @@ async function handleMessage(
 
   // Handle callback queries (permission buttons)
   if (msg.callbackData) {
-    const handled = broker.handlePermissionCallback(msg.callbackData, msg.address.chatId, msg.callbackMessageId);
+    const handled = broker.handlePermissionCallback(msg.callbackData, msg.address.chatId, msg.callbackMessageId, store);
     if (handled) {
       // Send confirmation
       const confirmMsg: OutboundMessage = {
@@ -550,7 +619,7 @@ async function handleMessage(
         text: 'Permission response recorded.',
         parseMode: 'plain',
       };
-      await deliver(adapter, confirmMsg);
+      await deliver(adapter, confirmMsg, { store });
     }
     ack();
     return;
@@ -574,7 +643,7 @@ async function handleMessage(
         text: rawData.userVisibleError,
         parseMode: 'plain',
         replyToMessageId: msg.messageId,
-      });
+      }, { store });
     } else if (rawData?.imageDownloadFailed || rawData?.attachmentDownloadFailed) {
       const failureLabel = rawData.failedLabel || (rawData.imageDownloadFailed ? 'image(s)' : 'attachment(s)');
       await deliver(adapter, {
@@ -582,7 +651,7 @@ async function handleMessage(
         text: `Failed to download ${rawData.failedCount ?? 1} ${failureLabel}. Please try sending again.`,
         parseMode: 'plain',
         replyToMessageId: msg.messageId,
-      });
+      }, { store });
     }
     ack();
     return;
@@ -610,7 +679,7 @@ async function handleMessage(
         const action = actionMap[normalized];
         const permId = pendingLinks[0].permissionRequestId;
         const callbackData = `perm:${action}:${permId}`;
-        const handled = broker.handlePermissionCallback(callbackData, msg.address.chatId);
+        const handled = broker.handlePermissionCallback(callbackData, msg.address.chatId, undefined, store);
         const label = normalized === '1' ? 'Allow' : normalized === '2' ? 'Allow Session' : 'Deny';
         if (handled) {
           await deliver(adapter, {
@@ -618,14 +687,14 @@ async function handleMessage(
             text: `${label}: recorded.`,
             parseMode: 'plain',
             replyToMessageId: msg.messageId,
-          });
+          }, { store });
         } else {
           await deliver(adapter, {
             address: msg.address,
             text: `Permission not found or already resolved.`,
             parseMode: 'plain',
             replyToMessageId: msg.messageId,
-          });
+          }, { store });
         }
         ack();
         return;
@@ -637,7 +706,7 @@ async function handleMessage(
           text: `Multiple pending permissions (${pendingLinks.length}). Please use the full command:\n/perm allow|allow_session|deny <id>`,
           parseMode: 'plain',
           replyToMessageId: msg.messageId,
-        });
+        }, { store });
         ack();
         return;
       }
@@ -672,7 +741,7 @@ async function handleMessage(
   if (!text && !hasAttachments) { ack(); return; }
 
   // Regular message — route to conversation engine
-  const binding = router.resolve(msg.address);
+  const binding = router.resolve(msg.address, { store });
 
   // Notify adapter that message processing is starting (e.g., typing indicator)
   adapter.onMessageStart?.(msg.address.chatId);
@@ -697,7 +766,7 @@ async function handleMessage(
     };
   }
 
-  const streamCfg = previewState ? getStreamConfig(adapter.channelType) : null;
+  const streamCfg = previewState ? getStreamConfig(adapter.channelType, store) : null;
 
   // Build the preview onPartialText callback (or undefined if preview not supported)
   const previewOnPartialText = (previewState && streamCfg) ? (fullText: string) => {
@@ -780,7 +849,7 @@ async function handleMessage(
     // Use text or empty string for image-only messages (prompt is still required by streamClaude)
     const promptText = text || (hasAttachments ? 'Describe this image.' : '');
 
-    const result = await engine.processMessage(binding, promptText, async (perm) => {
+    const result = await engine.processMessage(binding, promptText, async (perm, permissionOpts) => {
       await broker.forwardPermissionRequest(
         adapter,
         msg.address,
@@ -790,8 +859,13 @@ async function handleMessage(
         binding.codepilotSessionId,
         perm.suggestions,
         msg.messageId,
+        permissionOpts?.store || store,
       );
-    }, taskAbort.signal, hasAttachments ? msg.attachments : undefined, onPartialText, onToolEvent);
+    }, taskAbort.signal, hasAttachments ? msg.attachments : undefined, onPartialText, onToolEvent, {
+      channel: msg.address.channelType,
+      userId: msg.address.userId,
+      displayName: msg.address.displayName,
+    }, { store });
 
     // Finalize streaming card if adapter supports it.
     // onStreamEnd awaits any in-flight card creation and returns true if a card
@@ -810,7 +884,7 @@ async function handleMessage(
     // Skip if streaming card was finalized (content already in card).
     if (result.responseText) {
       if (!cardFinalized) {
-        await deliverResponse(adapter, msg.address, result.responseText, binding.codepilotSessionId, msg.messageId);
+        await deliverResponse(adapter, msg.address, result.responseText, binding.codepilotSessionId, msg.messageId, store);
       }
     } else if (result.hasError) {
       const errorResponse: OutboundMessage = {
@@ -819,7 +893,7 @@ async function handleMessage(
         parseMode: 'HTML',
         replyToMessageId: msg.messageId,
       };
-      await deliver(adapter, errorResponse);
+      await deliver(adapter, errorResponse, { sessionId: binding.codepilotSessionId, store });
     }
 
     // ── Outbound file sending ──────────────────────────────────
@@ -895,7 +969,7 @@ async function handleCommand(
   msg: InboundMessage,
   text: string,
 ): Promise<void> {
-  const { store } = getBridgeContext();
+  const store = getAdapterStore(adapter);
 
   // Extract command and args (handle /command@botname format)
   const parts = text.split(/\s+/);
@@ -918,7 +992,7 @@ async function handleCommand(
       text: `Command rejected: invalid input detected.`,
       parseMode: 'plain',
       replyToMessageId: msg.messageId,
-    });
+    }, { store });
     return;
   }
 
@@ -946,7 +1020,7 @@ async function handleCommand(
 
     case '/new': {
       // Abort any running task on the current session before creating a new one
-      const oldBinding = router.resolve(msg.address);
+      const oldBinding = router.resolve(msg.address, { store });
       const st = getState();
       const oldTask = st.activeTasks.get(oldBinding.codepilotSessionId);
       if (oldTask) {
@@ -963,7 +1037,7 @@ async function handleCommand(
         }
         workDir = validated;
       }
-      const binding = router.createBinding(msg.address, workDir);
+      const binding = router.createBinding(msg.address, { store, workingDirectory: workDir });
       response = `New session created.\nSession: <code>${binding.codepilotSessionId.slice(0, 8)}...</code>\nCWD: <code>${escapeHtml(binding.workingDirectory || '~')}</code>`;
       break;
     }
@@ -977,7 +1051,7 @@ async function handleCommand(
         response = 'Invalid session ID format. Expected a 32-64 character hex/UUID string.';
         break;
       }
-      const binding = router.bindToSession(msg.address, args);
+      const binding = router.bindToSession(msg.address, args, { store });
       if (binding) {
         response = `Bound to session <code>${args.slice(0, 8)}...</code>`;
       } else {
@@ -996,8 +1070,8 @@ async function handleCommand(
         response = 'Invalid path. Must be an absolute path without traversal sequences or special characters.';
         break;
       }
-      const binding = router.resolve(msg.address);
-      router.updateBinding(binding.id, { workingDirectory: validatedPath });
+      const binding = router.resolve(msg.address, { store });
+      router.updateBinding(binding.id, { workingDirectory: validatedPath }, { store });
       response = `Working directory set to <code>${escapeHtml(validatedPath)}</code>`;
       break;
     }
@@ -1007,14 +1081,14 @@ async function handleCommand(
         response = 'Usage: /mode plan|code|ask';
         break;
       }
-      const binding = router.resolve(msg.address);
-      router.updateBinding(binding.id, { mode: args });
+      const binding = router.resolve(msg.address, { store });
+      router.updateBinding(binding.id, { mode: args }, { store });
       response = `Mode set to <b>${args}</b>`;
       break;
     }
 
     case '/status': {
-      const binding = router.resolve(msg.address);
+      const binding = router.resolve(msg.address, { store });
       response = [
         '<b>Bridge Status</b>',
         '',
@@ -1027,11 +1101,11 @@ async function handleCommand(
     }
 
     case '/sessions': {
-      const bindings = router.listBindings(adapter.channelType);
+      const bindings = router.listBindings(adapter.channelType, { store });
       if (bindings.length === 0) {
         response = 'No sessions found.';
       } else {
-        const currentBinding = router.resolve(msg.address);
+        const currentBinding = router.resolve(msg.address, { store });
         // Sort by most recently active first
         const sorted = bindings.slice().sort((a, b) => {
           const ta = a.updatedAt || a.createdAt || '';
@@ -1055,7 +1129,7 @@ async function handleCommand(
     }
 
     case '/stop': {
-      const binding = router.resolve(msg.address);
+      const binding = router.resolve(msg.address, { store });
       const st = getState();
       const taskAbort = st.activeTasks.get(binding.codepilotSessionId);
       if (taskAbort) {
@@ -1079,7 +1153,7 @@ async function handleCommand(
         break;
       }
       const callbackData = `perm:${permAction}:${permId}`;
-      const handled = broker.handlePermissionCallback(callbackData, msg.address.chatId);
+      const handled = broker.handlePermissionCallback(callbackData, msg.address.chatId, undefined, store);
       if (handled) {
         response = `Permission ${permAction}: recorded.`;
       } else {
@@ -1115,7 +1189,7 @@ async function handleCommand(
       text: response,
       parseMode: 'HTML',
       replyToMessageId: msg.messageId,
-    });
+    }, { store });
   }
 }
 

--- a/src/lib/bridge/channel-adapter.ts
+++ b/src/lib/bridge/channel-adapter.ts
@@ -116,6 +116,17 @@ export abstract class BaseChannelAdapter {
    * Returns true if a card was finalized (caller should skip normal delivery).
    */
   onStreamEnd?(_chatId: string, _status: 'completed' | 'interrupted' | 'error', _responseText: string): Promise<boolean>;
+
+  /**
+   * Send a file (image or document) to the channel.
+   * Not all adapters support this — default returns failure.
+   * @param chatId - Platform-specific chat identifier
+   * @param filePath - Absolute path to the file on disk
+   * @param fileName - Display name for the file
+   */
+  async sendFile(_chatId: string, _filePath: string, _fileName: string): Promise<SendResult> {
+    return { ok: false, error: 'File sending not supported by this adapter' };
+  }
 }
 
 // ── Adapter Registry ────────────────────────────────────────────

--- a/src/lib/bridge/channel-adapter.ts
+++ b/src/lib/bridge/channel-adapter.ts
@@ -12,10 +12,16 @@ import type {
   PreviewCapabilities,
   SendResult,
 } from './types.js';
+import type { BridgeStore } from './host.js';
 
 export abstract class BaseChannelAdapter {
   /** Which channel type this adapter handles */
   abstract readonly channelType: ChannelType;
+
+  /** Unique adapter instance key. Defaults to the channel type for single-instance adapters. */
+  get instanceKey(): string {
+    return this.channelType;
+  }
 
   /**
    * Start the adapter (connect, begin polling/websocket, etc.).
@@ -131,15 +137,18 @@ export abstract class BaseChannelAdapter {
 
 // ── Adapter Registry ────────────────────────────────────────────
 
-const adapterFactories = new Map<string, () => BaseChannelAdapter>();
+export type AdapterFactory = (config?: unknown, store?: BridgeStore) => BaseChannelAdapter;
 
-export function registerAdapterFactory(channelType: string, factory: () => BaseChannelAdapter): void {
+const adapterFactories = new Map<string, AdapterFactory>();
+
+export function registerAdapterFactory(channelType: string, factory: AdapterFactory): void {
   adapterFactories.set(channelType, factory);
 }
 
-export function createAdapter(channelType: string): BaseChannelAdapter | null {
+export function createAdapter(channelType: ChannelType, config?: unknown, store?: BridgeStore): BaseChannelAdapter {
   const factory = adapterFactories.get(channelType);
-  return factory ? factory() : null;
+  if (!factory) throw new Error(`No adapter factory for ${channelType}`);
+  return factory(config, store);
 }
 
 export function getRegisteredTypes(): string[] {

--- a/src/lib/bridge/channel-router.ts
+++ b/src/lib/bridge/channel-router.ts
@@ -6,23 +6,52 @@
  */
 
 import type { ChannelAddress, ChannelBinding, ChannelType } from './types.js';
+import type { BridgeStore } from './host.js';
 import { getBridgeContext } from './context.js';
+
+export interface RouterOpts {
+  store: BridgeStore;
+  workingDirectory?: string;
+}
+
+type CreateBindingArg = RouterOpts | string | undefined;
+
+function getRouterStore(opts?: RouterOpts): BridgeStore {
+  return opts?.store ?? getBridgeContext().store;
+}
+
+function getCreateBindingOpts(arg: CreateBindingArg): {
+  store: BridgeStore;
+  workingDirectory?: string;
+} {
+  if (typeof arg === 'string') {
+    return {
+      store: getRouterStore(),
+      workingDirectory: arg,
+    };
+  }
+
+  return {
+    store: getRouterStore(arg),
+    workingDirectory: arg?.workingDirectory,
+  };
+}
 
 /**
  * Resolve an inbound address to a ChannelBinding.
  * If no binding exists, auto-creates a new session and binding.
  */
-export function resolve(address: ChannelAddress): ChannelBinding {
-  const { store } = getBridgeContext();
-  const existing = store.getChannelBinding(address.channelType, address.chatId);
+export function resolve(address: ChannelAddress, opts?: RouterOpts): ChannelBinding {
+  const store = getRouterStore(opts);
+  const existing = store.getChannelBinding(address.channelType, address.chatId, address.botName);
   if (existing) {
     // Verify the linked session still exists; if not, create a new one
     const session = store.getSession(existing.codepilotSessionId);
     if (session) return existing;
     // Session was deleted — recreate
-    return createBinding(address);
+    return createBinding(address, opts);
   }
-  return createBinding(address);
+  return createBinding(address, opts);
 }
 
 /**
@@ -30,9 +59,9 @@ export function resolve(address: ChannelAddress): ChannelBinding {
  */
 export function createBinding(
   address: ChannelAddress,
-  workingDirectory?: string,
+  optsOrWorkingDirectory?: CreateBindingArg,
 ): ChannelBinding {
-  const { store } = getBridgeContext();
+  const { store, workingDirectory } = getCreateBindingOpts(optsOrWorkingDirectory);
   const defaultCwd = workingDirectory
     || store.getSetting('bridge_default_work_dir')
     || process.env.HOME
@@ -55,6 +84,7 @@ export function createBinding(
 
   return store.upsertChannelBinding({
     channelType: address.channelType,
+    botName: address.botName,
     chatId: address.chatId,
     codepilotSessionId: session.id,
     sdkSessionId: '',
@@ -70,13 +100,15 @@ export function createBinding(
 export function bindToSession(
   address: ChannelAddress,
   codepilotSessionId: string,
+  opts?: RouterOpts,
 ): ChannelBinding | null {
-  const { store } = getBridgeContext();
+  const store = getRouterStore(opts);
   const session = store.getSession(codepilotSessionId);
   if (!session) return null;
 
   return store.upsertChannelBinding({
     channelType: address.channelType,
+    botName: address.botName,
     chatId: address.chatId,
     codepilotSessionId,
     workingDirectory: session.working_directory,
@@ -90,13 +122,14 @@ export function bindToSession(
 export function updateBinding(
   id: string,
   updates: Partial<Pick<ChannelBinding, 'sdkSessionId' | 'workingDirectory' | 'model' | 'mode' | 'active'>>,
+  opts?: RouterOpts,
 ): void {
-  getBridgeContext().store.updateChannelBinding(id, updates);
+  getRouterStore(opts).updateChannelBinding(id, updates);
 }
 
 /**
  * List all bindings, optionally filtered by channel type.
  */
-export function listBindings(channelType?: ChannelType): ChannelBinding[] {
-  return getBridgeContext().store.listChannelBindings(channelType);
+export function listBindings(channelType?: ChannelType, opts?: RouterOpts): ChannelBinding[] {
+  return getRouterStore(opts).listChannelBindings(channelType);
 }

--- a/src/lib/bridge/context.ts
+++ b/src/lib/bridge/context.ts
@@ -14,9 +14,12 @@ import type {
   PermissionGateway,
   LifecycleHooks,
 } from './host.js';
+import type { FeishuBotConfig } from './types.js';
 
 export interface BridgeContext {
   store: BridgeStore;
+  feishuBotConfigs?: FeishuBotConfig[];
+  botStores?: Map<string, BridgeStore>;
   llm: LLMProvider;
   permissions: PermissionGateway;
   lifecycle: LifecycleHooks;

--- a/src/lib/bridge/conversation-engine.ts
+++ b/src/lib/bridge/conversation-engine.ts
@@ -159,6 +159,9 @@ export async function processMessage(
             const filePath = path.join(uploadDir, `${Date.now()}-${safeName}`);
             const buffer = Buffer.from(f.data, 'base64');
             fs.writeFileSync(filePath, buffer);
+            // Back-populate disk path onto original FileAttachment so LLM
+            // providers can reference non-image files by path.
+            f.filePath = filePath;
             return { id: f.id, name: f.name, type: f.type, size: buffer.length, filePath };
           });
           savedContent = `<!--files:${JSON.stringify(fileMeta)}-->${text}`;

--- a/src/lib/bridge/conversation-engine.ts
+++ b/src/lib/bridge/conversation-engine.ts
@@ -45,6 +45,49 @@ export type OnPartialText = (fullText: string) => void;
  */
 export type OnToolEvent = (toolId: string, toolName: string, status: 'running' | 'complete' | 'error') => void;
 
+// ── Outbound file detection ──────────────────────────────────
+
+/** Extensions that should be sent back to IM as image messages. */
+const IMAGE_EXTENSIONS = new Set([
+  '.png', '.jpg', '.jpeg', '.gif', '.webp', '.bmp', '.tiff', '.ico', '.svg',
+]);
+
+/** Extensions that should be sent back to IM as file messages. */
+const DOCUMENT_EXTENSIONS = new Set([
+  '.pdf', '.csv', '.xlsx', '.xls', '.docx', '.doc',
+  '.pptx', '.ppt', '.zip', '.tar', '.gz', '.7z',
+  '.mp3', '.mp4', '.wav', '.ogg', '.txt',
+]);
+
+/**
+ * Check if a file path has a sendable extension (image or document).
+ */
+export function isSendableFile(filePath: string): boolean {
+  const ext = filePath.slice(filePath.lastIndexOf('.')).toLowerCase();
+  return IMAGE_EXTENSIONS.has(ext) || DOCUMENT_EXTENSIONS.has(ext);
+}
+
+/**
+ * Check if a file path is an image based on extension.
+ */
+export function isImageFile(filePath: string): boolean {
+  const ext = filePath.slice(filePath.lastIndexOf('.')).toLowerCase();
+  return IMAGE_EXTENSIONS.has(ext);
+}
+
+/**
+ * Extract created file paths from a tool_use event.
+ * Only processes "Edit" tool events (which cover both Write and Edit in the Codex SDK mapping).
+ */
+export function extractCreatedFiles(toolName: string, input: unknown): string[] {
+  if (toolName !== 'Edit') return [];
+  const files = (input as Record<string, unknown>)?.files;
+  if (!Array.isArray(files)) return [];
+  return files
+    .filter((f: any) => f.kind === 'create' && typeof f.path === 'string')
+    .map((f: any) => f.path as string);
+}
+
 export interface ConversationResult {
   responseText: string;
   tokenUsage: TokenUsage | null;
@@ -54,6 +97,8 @@ export interface ConversationResult {
   permissionRequests: PermissionRequestInfo[];
   /** SDK session ID captured from status/result events, for session resume */
   sdkSessionId: string | null;
+  /** Absolute paths to files created by Claude during the conversation (only sendable types) */
+  createdFiles: string[];
 }
 
 /**
@@ -83,6 +128,7 @@ export async function processMessage(
       errorMessage: 'Session is busy processing another request',
       permissionRequests: [],
       sdkSessionId: null,
+      createdFiles: [],
     };
   }
 
@@ -214,6 +260,7 @@ async function consumeStream(
   let errorMessage = '';
   const seenToolResultIds = new Set<string>();
   const permissionRequests: PermissionRequestInfo[] = [];
+  const createdFiles: string[] = [];
   let capturedSdkSessionId: string | null = null;
 
   try {
@@ -256,6 +303,10 @@ async function consumeStream(
               });
               if (onToolEvent) {
                 try { onToolEvent(toolData.id, toolData.name, 'running'); } catch { /* non-critical */ }
+              }
+              const newFiles = extractCreatedFiles(toolData.name, toolData.input);
+              for (const f of newFiles) {
+                if (isSendableFile(f)) createdFiles.push(f);
               }
             } catch { /* skip */ }
             break;
@@ -397,6 +448,7 @@ async function consumeStream(
       errorMessage,
       permissionRequests,
       sdkSessionId: capturedSdkSessionId,
+      createdFiles,
     };
   } catch (e) {
     // Best-effort save on stream error
@@ -429,6 +481,7 @@ async function consumeStream(
       errorMessage: isAbort ? 'Task stopped by user' : (e instanceof Error ? e.message : 'Stream consumption error'),
       permissionRequests,
       sdkSessionId: capturedSdkSessionId,
+      createdFiles,
     };
   }
 }

--- a/src/lib/bridge/conversation-engine.ts
+++ b/src/lib/bridge/conversation-engine.ts
@@ -250,6 +250,7 @@ export async function processMessage(
       senderChannel: sender?.channel || binding.channelType,
       senderUserId: sender?.userId,
       senderName: sender?.displayName,
+      botName: binding.botName,
     });
 
     // Consume the stream server-side (replicate collectStreamResponse pattern).

--- a/src/lib/bridge/conversation-engine.ts
+++ b/src/lib/bridge/conversation-engine.ts
@@ -10,6 +10,7 @@ import fs from 'fs';
 import path from 'path';
 import type { ChannelBinding } from './types.js';
 import type {
+  BridgeStore,
   FileAttachment,
   SSEEvent,
   TokenUsage,
@@ -31,7 +32,10 @@ export interface PermissionRequestInfo {
  * so we must forward the request to the IM *during* stream consumption,
  * not after it returns.
  */
-export type OnPermissionRequest = (perm: PermissionRequestInfo) => Promise<void>;
+export type OnPermissionRequest = (
+  perm: PermissionRequestInfo,
+  opts?: { store?: BridgeStore },
+) => Promise<void>;
 
 /**
  * Callback invoked on each `text` SSE event with the full accumulated text so far.
@@ -44,6 +48,17 @@ export type OnPartialText = (fullText: string) => void;
  * Used by bridge-manager to forward tool progress to adapters for real-time display.
  */
 export type OnToolEvent = (toolId: string, toolName: string, status: 'running' | 'complete' | 'error') => void;
+
+/**
+ * Identity of the IM user who sent the inbound message.
+ * Forwarded down to the LLM provider so CC spawns with per-user env vars
+ * (CTI_SENDER_CHANNEL / CTI_SENDER_USER_ID / CTI_SENDER_NAME).
+ */
+export interface SenderInfo {
+  channel?: string;
+  userId?: string;
+  displayName?: string;
+}
 
 // ── Outbound file detection ──────────────────────────────────
 
@@ -113,13 +128,17 @@ export async function processMessage(
   files?: FileAttachment[],
   onPartialText?: OnPartialText,
   onToolEvent?: OnToolEvent,
+  sender?: SenderInfo,
+  opts?: { store?: BridgeStore },
 ): Promise<ConversationResult> {
-  const { store, llm } = getBridgeContext();
+  const ctx = getBridgeContext();
+  const s = opts?.store || ctx.store;
+  const { llm } = ctx;
   const sessionId = binding.codepilotSessionId;
 
   // Acquire session lock
   const lockId = crypto.randomBytes(8).toString('hex');
-  const lockAcquired = store.acquireSessionLock(sessionId, lockId, `bridge-${binding.channelType}`, 600);
+  const lockAcquired = s.acquireSessionLock(sessionId, lockId, `bridge-${binding.channelType}`, 600);
   if (!lockAcquired) {
     return {
       responseText: '',
@@ -132,16 +151,16 @@ export async function processMessage(
     };
   }
 
-  store.setSessionRuntimeStatus(sessionId, 'running');
+  s.setSessionRuntimeStatus(sessionId, 'running');
 
   // Lock renewal interval
   const renewalInterval = setInterval(() => {
-    try { store.renewSessionLock(sessionId, lockId, 600); } catch { /* best effort */ }
+    try { s.renewSessionLock(sessionId, lockId, 600); } catch { /* best effort */ }
   }, 60_000);
 
   try {
     // Resolve session early — needed for workingDirectory and provider resolution
-    const session = store.getSession(sessionId);
+    const session = s.getSession(sessionId);
 
     // Save user message — persist file attachments to disk using the same
     // <!--files:JSON--> format as the desktop chat route, so the UI can render them.
@@ -173,21 +192,21 @@ export async function processMessage(
         savedContent = `[${files.length} image(s) attached] ${text}`;
       }
     }
-    store.addMessage(sessionId, 'user', savedContent);
+    s.addMessage(sessionId, 'user', savedContent);
 
     // Resolve provider
     let resolvedProvider: import('./host.js').BridgeApiProvider | undefined;
     const providerId = session?.provider_id || '';
     if (providerId && providerId !== 'env') {
-      resolvedProvider = store.getProvider(providerId);
+      resolvedProvider = s.getProvider(providerId);
     }
     if (!resolvedProvider) {
-      const defaultId = store.getDefaultProviderId();
-      if (defaultId) resolvedProvider = store.getProvider(defaultId);
+      const defaultId = s.getDefaultProviderId();
+      if (defaultId) resolvedProvider = s.getProvider(defaultId);
     }
 
     // Effective model
-    const effectiveModel = binding.model || session?.model || store.getSetting('default_model') || undefined;
+    const effectiveModel = binding.model || session?.model || s.getSetting('default_model') || undefined;
 
     // Permission mode from binding mode
     let permissionMode: string;
@@ -198,7 +217,7 @@ export async function processMessage(
     }
 
     // Load conversation history for context
-    const { messages: recentMsgs } = store.getMessages(sessionId, { limit: 50 });
+    const { messages: recentMsgs } = s.getMessages(sessionId, { limit: 50 });
     const historyMsgs = recentMsgs.slice(0, -1).map(m => ({
       role: m.role as 'user' | 'assistant',
       content: m.content,
@@ -226,18 +245,21 @@ export async function processMessage(
       conversationHistory: historyMsgs,
       files,
       onRuntimeStatusChange: (status: string) => {
-        try { store.setSessionRuntimeStatus(sessionId, status); } catch { /* best effort */ }
+        try { s.setSessionRuntimeStatus(sessionId, status); } catch { /* best effort */ }
       },
+      senderChannel: sender?.channel || binding.channelType,
+      senderUserId: sender?.userId,
+      senderName: sender?.displayName,
     });
 
     // Consume the stream server-side (replicate collectStreamResponse pattern).
     // Permission requests are forwarded immediately via the callback during streaming
     // because the stream blocks until permission is resolved — we can't wait until after.
-    return await consumeStream(stream, sessionId, onPermissionRequest, onPartialText, onToolEvent);
+    return await consumeStream(stream, sessionId, onPermissionRequest, onPartialText, onToolEvent, s);
   } finally {
     clearInterval(renewalInterval);
-    store.releaseSessionLock(sessionId, lockId);
-    store.setSessionRuntimeStatus(sessionId, 'idle');
+    s.releaseSessionLock(sessionId, lockId);
+    s.setSessionRuntimeStatus(sessionId, 'idle');
   }
 }
 
@@ -251,8 +273,9 @@ async function consumeStream(
   onPermissionRequest?: OnPermissionRequest,
   onPartialText?: OnPartialText,
   onToolEvent?: OnToolEvent,
+  store?: BridgeStore,
 ): Promise<ConversationResult> {
-  const { store } = getBridgeContext();
+  const s = store || getBridgeContext().store;
   const reader = stream.getReader();
   const contentBlocks: MessageContentBlock[] = [];
   let currentText = '';
@@ -266,9 +289,25 @@ async function consumeStream(
   const createdFiles: string[] = [];
   let capturedSdkSessionId: string | null = null;
 
+  // Idle timeout: abort if no stream data received within the limit (default 5 min).
+  // Covers stuck CC subprocesses, zombie processes, and hung tool calls.
+  const STREAM_IDLE_TIMEOUT_MS = parseInt(process.env.CTI_STREAM_IDLE_TIMEOUT_MS || '', 10) || 300_000;
+  function readWithIdleTimeout() {
+    let timer: ReturnType<typeof setTimeout>;
+    return Promise.race([
+      reader.read(),
+      new Promise<never>((_, reject) => {
+        timer = setTimeout(
+          () => reject(new Error(`Stream idle timeout: no data for ${STREAM_IDLE_TIMEOUT_MS / 1000}s`)),
+          STREAM_IDLE_TIMEOUT_MS,
+        );
+      }),
+    ]).finally(() => clearTimeout(timer!));
+  }
+
   try {
     while (true) {
-      const { done, value } = await reader.read();
+      const { done, value } = await readWithIdleTimeout();
       if (done) break;
 
       const lines = value.split('\n');
@@ -359,7 +398,7 @@ async function consumeStream(
               // Forward immediately — the stream blocks until the permission is
               // resolved, so we must send the IM prompt *now*, not after the stream ends.
               if (onPermissionRequest) {
-                onPermissionRequest(perm).catch((err) => {
+                onPermissionRequest(perm, { store: s }).catch((err) => {
                   console.error('[conversation-engine] Failed to forward permission request:', err);
                 });
               }
@@ -372,10 +411,10 @@ async function consumeStream(
               const statusData = JSON.parse(event.data);
               if (statusData.session_id) {
                 capturedSdkSessionId = statusData.session_id;
-                store.updateSdkSessionId(sessionId, statusData.session_id);
+                s.updateSdkSessionId(sessionId, statusData.session_id);
               }
               if (statusData.model) {
-                store.updateSessionModel(sessionId, statusData.model);
+                s.updateSessionModel(sessionId, statusData.model);
               }
             } catch { /* skip */ }
             break;
@@ -385,7 +424,7 @@ async function consumeStream(
             try {
               const taskData = JSON.parse(event.data);
               if (taskData.session_id && taskData.todos) {
-                store.syncSdkTasks(taskData.session_id, taskData.todos);
+                s.syncSdkTasks(taskData.session_id, taskData.todos);
               }
             } catch { /* skip */ }
             break;
@@ -403,7 +442,7 @@ async function consumeStream(
               if (resultData.is_error) hasError = true;
               if (resultData.session_id) {
                 capturedSdkSessionId = resultData.session_id;
-                store.updateSdkSessionId(sessionId, resultData.session_id);
+                s.updateSdkSessionId(sessionId, resultData.session_id);
               }
             } catch { /* skip */ }
             break;
@@ -433,7 +472,7 @@ async function consumeStream(
             .trim();
 
       if (content) {
-        store.addMessage(sessionId, 'assistant', content, tokenUsage ? JSON.stringify(tokenUsage) : null);
+        s.addMessage(sessionId, 'assistant', content, tokenUsage ? JSON.stringify(tokenUsage) : null);
       }
     }
 
@@ -470,7 +509,7 @@ async function consumeStream(
             .join('\n\n')
             .trim();
       if (content) {
-        store.addMessage(sessionId, 'assistant', content);
+        s.addMessage(sessionId, 'assistant', content);
       }
     }
 

--- a/src/lib/bridge/delivery-layer.ts
+++ b/src/lib/bridge/delivery-layer.ts
@@ -13,6 +13,7 @@ import type {
 import type { TelegramChunk } from './markdown/telegram.js';
 import { PLATFORM_LIMITS as limits } from './types.js';
 import type { BaseChannelAdapter } from './channel-adapter.js';
+import type { BridgeStore } from './host.js';
 import { getBridgeContext } from './context.js';
 import { ChatRateLimiter } from './security/rate-limiter.js';
 
@@ -140,20 +141,21 @@ export async function deliver(
   opts?: {
     sessionId?: string;
     dedupKey?: string;
+    store?: BridgeStore;
   },
 ): Promise<SendResult> {
-  const { store } = getBridgeContext();
+  const s = opts?.store || getBridgeContext().store;
 
   // Dedup check
   if (opts?.dedupKey) {
-    if (store.checkDedup(opts.dedupKey)) {
+    if (s.checkDedup(opts.dedupKey)) {
       return { ok: true, messageId: undefined };
     }
   }
 
   // Periodically clean up expired dedup entries (1 in 100 chance)
   if (Math.random() < 0.01) {
-    try { store.cleanupExpiredDedup(); } catch { /* best effort */ }
+    try { s.cleanupExpiredDedup(); } catch { /* best effort */ }
   }
 
   const limit = limits[adapter.channelType] || 4096;
@@ -198,7 +200,7 @@ export async function deliver(
     // Track outbound reference
     if (result.messageId && opts?.sessionId) {
       try {
-        store.insertOutboundRef({
+        s.insertOutboundRef({
           channelType: adapter.channelType,
           chatId: message.address.chatId,
           codepilotSessionId: opts.sessionId,
@@ -211,12 +213,12 @@ export async function deliver(
 
   // Mark as delivered for dedup
   if (opts?.dedupKey) {
-    try { store.insertDedup(opts.dedupKey); } catch { /* best effort */ }
+    try { s.insertDedup(opts.dedupKey); } catch { /* best effort */ }
   }
 
   // Audit log
   try {
-    store.insertAuditLog({
+    s.insertAuditLog({
       channelType: adapter.channelType,
       chatId: message.address.chatId,
       direction: 'outbound',
@@ -284,18 +286,18 @@ export async function deliverRendered(
   adapter: BaseChannelAdapter,
   address: ChannelAddress,
   chunks: TelegramChunk[],
-  opts?: { sessionId?: string; dedupKey?: string; replyToMessageId?: string },
+  opts?: { sessionId?: string; dedupKey?: string; replyToMessageId?: string; store?: BridgeStore },
 ): Promise<SendResult> {
-  const { store } = getBridgeContext();
+  const s = opts?.store || getBridgeContext().store;
 
   // Dedup check
   if (opts?.dedupKey) {
-    if (store.checkDedup(opts.dedupKey)) {
+    if (s.checkDedup(opts.dedupKey)) {
       return { ok: true, messageId: undefined };
     }
   }
   if (Math.random() < 0.01) {
-    try { store.cleanupExpiredDedup(); } catch { /* best effort */ }
+    try { s.cleanupExpiredDedup(); } catch { /* best effort */ }
   }
 
   let lastMessageId: string | undefined;
@@ -329,7 +331,7 @@ export async function deliverRendered(
 
     if (result.messageId && opts?.sessionId) {
       try {
-        store.insertOutboundRef({
+        s.insertOutboundRef({
           channelType: adapter.channelType,
           chatId: address.chatId,
           codepilotSessionId: opts.sessionId,
@@ -347,11 +349,11 @@ export async function deliverRendered(
   }
 
   if (opts?.dedupKey) {
-    try { store.insertDedup(opts.dedupKey); } catch { /* best effort */ }
+    try { s.insertDedup(opts.dedupKey); } catch { /* best effort */ }
   }
 
   try {
-    store.insertAuditLog({
+    s.insertAuditLog({
       channelType: adapter.channelType,
       chatId: address.chatId,
       direction: 'outbound',

--- a/src/lib/bridge/host.ts
+++ b/src/lib/bridge/host.ts
@@ -128,6 +128,7 @@ export interface OutboundRefInput {
 /** Input for upserting a channel binding. */
 export interface UpsertChannelBindingInput {
   channelType: string;
+  botName?: string;
   chatId: string;
   codepilotSessionId: string;
   sdkSessionId?: string;
@@ -145,7 +146,7 @@ export interface BridgeStore {
   getSetting(key: string): string | null;
 
   // ── Channel bindings ──
-  getChannelBinding(channelType: string, chatId: string): ChannelBinding | null;
+  getChannelBinding(channelType: string, chatId: string, botName?: string): ChannelBinding | null;
   upsertChannelBinding(data: UpsertChannelBindingInput): ChannelBinding;
   updateChannelBinding(id: string, updates: Partial<ChannelBinding>): void;
   listChannelBindings(channelType?: ChannelType): ChannelBinding[];
@@ -215,6 +216,12 @@ export interface StreamChatParams {
   conversationHistory?: Array<{ role: 'user' | 'assistant'; content: string }>;
   files?: FileAttachment[];
   onRuntimeStatusChange?: (status: string) => void;
+  /** IM channel type (feishu | telegram | discord | ...) the message came from. */
+  senderChannel?: string;
+  /** Platform-specific user id of the sender (feishu open_id, telegram numeric id, etc). */
+  senderUserId?: string;
+  /** Optional display name of the sender, for logs and prompts. */
+  senderName?: string;
 }
 
 export interface LLMProvider {

--- a/src/lib/bridge/host.ts
+++ b/src/lib/bridge/host.ts
@@ -222,6 +222,8 @@ export interface StreamChatParams {
   senderUserId?: string;
   /** Optional display name of the sender, for logs and prompts. */
   senderName?: string;
+  /** Bot instance name for per-bot env isolation (lark-cli config dir). */
+  botName?: string;
 }
 
 export interface LLMProvider {

--- a/src/lib/bridge/markdown/feishu.ts
+++ b/src/lib/bridge/markdown/feishu.ts
@@ -93,15 +93,32 @@ export function htmlToFeishuMarkdown(html: string): string {
 
 /**
  * Build tool progress markdown lines.
- * Each tool shows an icon based on status: 🔄 Running, ✅ Complete, ❌ Error.
+ *
+ * Always renders a non-empty line as long as at least one tool has been seen,
+ * so the card never collapses back to "💭 Thinking..." between two tool calls
+ * just because the previous one moved from running → complete.
+ *
+ * Format:
+ *   - running tool present:  "⏳ <currentToolName> · 已完成 X/Y 步"
+ *   - all tools complete:    "✅ 已完成 X 步"
+ *   - tools.length === 0:    "" (no tools yet)
  */
 export function buildToolProgressMarkdown(tools: ToolCallInfo[]): string {
   if (tools.length === 0) return '';
-  const lines = tools.map((tc) => {
-    const icon = tc.status === 'running' ? '🔄' : tc.status === 'complete' ? '✅' : '❌';
-    return `${icon} \`${tc.name}\``;
-  });
-  return lines.join('\n');
+  const total = tools.length;
+  const completed = tools.filter(
+    (tc) => tc.status === 'complete' || tc.status === 'error',
+  ).length;
+  // Pick the most recently added running tool (Map preserves insertion order).
+  let current: ToolCallInfo | undefined;
+  for (const tc of tools) {
+    if (tc.status === 'running') current = tc;
+  }
+  if (current) {
+    const name = current.name || 'tool';
+    return `⏳ ${name} · 已完成 ${completed}/${total} 步`;
+  }
+  return `✅ 已完成 ${total} 步`;
 }
 
 /**
@@ -177,9 +194,17 @@ export function buildFinalCardJson(
   });
 }
 
+function normalizePermissionCardMarkdown(text: string): string {
+  return preprocessFeishuMarkdown(text)
+    .replace(/^\*\*Permission Required\*\*\s*/u, '')
+    .replace(/\n*Choose an action:\s*$/u, '')
+    .trim();
+}
+
 /**
  * Build a permission card with real action buttons (column_set layout).
- * Structure aligned with CodePilot's working Feishu outbound implementation.
+ * Uses the same warning-card visual language as OpenClaw approvals while
+ * keeping bridge-native button semantics intact.
  * Returns the card JSON string for msg_type: 'interactive'.
  */
 export function buildPermissionButtonCard(
@@ -187,11 +212,12 @@ export function buildPermissionButtonCard(
   permissionRequestId: string,
   chatId?: string,
 ): string {
+  const content = normalizePermissionCardMarkdown(text);
   const buttons = [
     { label: 'Allow', type: 'primary', action: 'allow' },
     { label: 'Allow Session', type: 'default', action: 'allow_session' },
     { label: 'Deny', type: 'danger', action: 'deny' },
-  ];
+  ] as const;
 
   const buttonColumns = buttons.map((btn) => ({
     tag: 'column',
@@ -207,29 +233,25 @@ export function buildPermissionButtonCard(
 
   return JSON.stringify({
     schema: '2.0',
-    config: { wide_screen_mode: true },
+    config: { wide_screen_mode: true, update_multi: true },
     header: {
-      title: { tag: 'plain_text', content: 'Permission Required' },
-      template: 'blue',
-      icon: { tag: 'standard_icon', token: 'lock-chat_filled' },
+      title: { tag: 'plain_text', content: 'Approval Required' },
+      template: 'orange',
       padding: '12px 12px 12px 12px',
+      text_tag_list: [
+        { tag: 'text_tag', text: { tag: 'plain_text', content: 'pending' }, color: 'orange' },
+      ],
     },
     body: {
       elements: [
-        { tag: 'markdown', content: text, text_size: 'normal' },
-        { tag: 'markdown', content: '⏱ This request will expire in 5 minutes', text_size: 'notation' },
+        { tag: 'markdown', content: content, text_size: 'normal', text_align: 'left' },
+        { tag: 'markdown', content: 'This approval stays interactive in Feishu. Use the buttons below.', text_size: 'notation' },
         { tag: 'hr' },
         {
           tag: 'column_set',
           flex_mode: 'none',
           horizontal_align: 'left',
           columns: buttonColumns,
-        },
-        { tag: 'hr' },
-        {
-          tag: 'markdown',
-          content: 'Or reply: `1` Allow · `2` Allow Session · `3` Deny',
-          text_size: 'notation',
         },
       ],
     },

--- a/src/lib/bridge/permission-broker.ts
+++ b/src/lib/bridge/permission-broker.ts
@@ -12,6 +12,7 @@
 import type { PermissionUpdate } from '@anthropic-ai/claude-agent-sdk';
 import type { ChannelAddress, OutboundMessage } from './types.js';
 import type { BaseChannelAdapter } from './channel-adapter.js';
+import type { BridgeStore } from './host.js';
 import { deliver } from './delivery-layer.js';
 import { getBridgeContext } from './context.js';
 import { escapeHtml } from './adapters/telegram-utils.js';
@@ -34,8 +35,9 @@ export async function forwardPermissionRequest(
   sessionId?: string,
   suggestions?: unknown[],
   replyToMessageId?: string,
+  store?: BridgeStore,
 ): Promise<void> {
-  const { store } = getBridgeContext();
+  const s = store || getBridgeContext().store;
 
   // Dedup: prevent duplicate forwarding of the same permission request
   const now = Date.now();
@@ -86,7 +88,7 @@ export async function forwardPermissionRequest(
       replyToMessageId,
     };
 
-    result = await deliver(adapter, plainMessage, { sessionId });
+    result = await deliver(adapter, plainMessage, { sessionId, store: s });
     console.log(
       `[permission-broker] Sent plain-text permission prompt for ${channelLabel}: ${permissionRequestId}`,
     );
@@ -114,13 +116,13 @@ export async function forwardPermissionRequest(
       replyToMessageId,
     };
 
-    result = await deliver(adapter, message, { sessionId });
+    result = await deliver(adapter, message, { sessionId, store: s });
   }
 
   // Record the link so we can match callback queries back to this permission
   if (result.ok && result.messageId) {
     try {
-      store.insertPermissionLink({
+      s.insertPermissionLink({
         permissionRequestId,
         channelType: adapter.channelType,
         chatId: address.chatId,
@@ -145,8 +147,11 @@ export function handlePermissionCallback(
   callbackData: string,
   callbackChatId: string,
   callbackMessageId?: string,
+  store?: BridgeStore,
 ): boolean {
-  const { store, permissions } = getBridgeContext();
+  const ctx = getBridgeContext();
+  const s = store || ctx.store;
+  const { permissions } = ctx;
 
   // Parse callback data: perm:action:permId
   const parts = callbackData.split(':');
@@ -156,7 +161,7 @@ export function handlePermissionCallback(
   const permissionRequestId = parts.slice(2).join(':'); // permId might contain colons
 
   // Look up the permission link to validate origin and check dedup
-  const link = store.getPermissionLink(permissionRequestId);
+  const link = s.getPermissionLink(permissionRequestId);
   if (!link) {
     console.warn(`[permission-broker] No permission link found for ${permissionRequestId}`);
     return false;
@@ -184,7 +189,7 @@ export function handlePermissionCallback(
   // to prevent race conditions with concurrent button clicks
   let claimed: boolean;
   try {
-    claimed = store.markPermissionLinkResolved(permissionRequestId);
+    claimed = s.markPermissionLinkResolved(permissionRequestId);
   } catch {
     return false;
   }

--- a/src/lib/bridge/types.ts
+++ b/src/lib/bridge/types.ts
@@ -21,6 +21,7 @@ export type ChannelType = string;
 /** Unique address of a user within a channel */
 export interface ChannelAddress {
   channelType: ChannelType;
+  botName?: string;      // Logical bot instance name when multiple bots share a channel type
   chatId: string;        // Platform-specific chat/channel identifier
   userId?: string;       // Platform-specific user identifier (optional for group chats)
   displayName?: string;  // Human-readable name for audit logs
@@ -90,6 +91,7 @@ export interface SendResult {
 export interface ChannelBinding {
   id: string;
   channelType: ChannelType;
+  botName?: string;
   chatId: string;
   /** CodePilot session ID this chat is bound to */
   codepilotSessionId: string;
@@ -187,3 +189,16 @@ export const PLATFORM_LIMITS: Record<string, number> = {
   qq: 2000,
   weixin: 4000,
 };
+
+export interface FeishuBotConfig {
+  name: string;
+  appId: string;
+  appSecret: string;
+  domain?: 'feishu' | 'lark';
+  allowedUsers?: string[];
+  requireMention?: boolean;
+  groupPolicy?: 'open' | 'disabled' | 'allowlist';
+  groupAllowFrom?: string[];
+  workingDirectory?: string;
+  userOverrides?: Map<string, { workingDirectory?: string }>;
+}

--- a/src/lib/bridge/types.ts
+++ b/src/lib/bridge/types.ts
@@ -120,6 +120,7 @@ export interface BridgeStatus {
 
 /** Status of a single channel adapter */
 export interface AdapterStatus {
+  instanceKey: string;
   channelType: ChannelType;
   running: boolean;
   connectedAt: string | null;
@@ -199,6 +200,6 @@ export interface FeishuBotConfig {
   requireMention?: boolean;
   groupPolicy?: 'open' | 'disabled' | 'allowlist';
   groupAllowFrom?: string[];
-  workingDirectory?: string;
+  workingDirectory: string;
   userOverrides?: Map<string, { workingDirectory?: string }>;
 }

--- a/src/lib/bridge/types.ts
+++ b/src/lib/bridge/types.ts
@@ -201,5 +201,6 @@ export interface FeishuBotConfig {
   groupPolicy?: 'open' | 'disabled' | 'allowlist';
   groupAllowFrom?: string[];
   workingDirectory: string;
+  larkCliConfigDir?: string;
   userOverrides?: Map<string, { workingDirectory?: string }>;
 }

--- a/src/llm-provider.ts
+++ b/src/llm-provider.ts
@@ -13,6 +13,7 @@ import type { LLMProvider, StreamChatParams, FileAttachment } from 'claude-to-im
 import type { PendingPermissions } from './permission-gateway.js';
 
 import { sseEvent } from './sse-utils.js';
+import { detectInjection, isExternalTool } from 'content-guard';
 
 // ── Environment isolation ──
 
@@ -427,6 +428,8 @@ export interface StreamState {
   hasReceivedResult: boolean;
   /** True once any text_delta has been emitted via stream_event. */
   hasStreamedText: boolean;
+  /** Maps tool_use_id → tool name, used to identify external tools for injection scanning. */
+  toolNames: Map<string, string>;
   /**
    * Full text captured from the final `assistant` message.
    * NOT emitted during normal flow (stream_event deltas handle that).
@@ -456,7 +459,7 @@ export class SDKLLMProvider implements LLMProvider {
           // Ring-buffer for recent stderr output (max 4 KB)
           const MAX_STDERR = 4096;
           let stderrBuf = '';
-          const state: StreamState = { hasReceivedResult: false, hasStreamedText: false, lastAssistantText: '' };
+          const state: StreamState = { hasReceivedResult: false, hasStreamedText: false, toolNames: new Map(), lastAssistantText: '' };
 
           try {
             const cleanEnv = buildSubprocessEnv();
@@ -634,6 +637,7 @@ export function handleMessage(
         event.type === 'content_block_start' &&
         event.content_block.type === 'tool_use'
       ) {
+        state.toolNames.set(event.content_block.id, event.content_block.name);
         controller.enqueue(
           sseEvent('tool_use', {
             id: event.content_block.id,
@@ -658,6 +662,7 @@ export function handleMessage(
           if (block.type === 'text' && block.text) {
             state.lastAssistantText += (state.lastAssistantText ? '\n' : '') + block.text;
           } else if (block.type === 'tool_use') {
+            state.toolNames.set(block.id, block.name);
             controller.enqueue(
               sseEvent('tool_use', {
                 id: block.id,
@@ -678,9 +683,35 @@ export function handleMessage(
         for (const block of content) {
           if (typeof block === 'object' && block !== null && 'type' in block && block.type === 'tool_result') {
             const rb = block as { tool_use_id: string; content?: unknown; is_error?: boolean };
-            const text = typeof rb.content === 'string'
+            let text = typeof rb.content === 'string'
               ? rb.content
               : JSON.stringify(rb.content ?? '');
+
+            // Content Guard: only scan external tool results for injection.
+            // Local tools (Read, Bash, Grep, Glob, Edit, Write, etc.) are trusted.
+            const toolName = state.toolNames.get(rb.tool_use_id) ?? '';
+            if (isExternalTool(toolName)) {
+              const scan = detectInjection(text);
+              if (scan.detected) {
+                const ruleIds = scan.matches.map(m => m.ruleId).join(',');
+                console.warn(
+                  `[content-guard] External tool "${toolName}" flagged: score=${scan.score}, ` +
+                  `severity=${scan.severity}, rules=[${ruleIds}]`,
+                );
+                if (scan.score >= 15) {
+                  text = `[BLOCKED: Prompt injection detected in ${toolName} output. ` +
+                    `Severity: ${scan.severity}, score: ${scan.score}. ` +
+                    `Rules: ${ruleIds}. Original content has been removed for safety.]`;
+                } else {
+                  text = `<external_content source="${toolName}" trust="suspicious" ` +
+                    `warning="Injection detected: ${scan.summary}">\n` +
+                    `${text}\n</external_content>`;
+                }
+              } else if (text.length > 200) {
+                text = `<external_content source="${toolName}" trust="untrusted">\n${text}\n</external_content>`;
+              }
+            }
+
             controller.enqueue(
               sseEvent('tool_result', {
                 tool_use_id: rb.tool_use_id,

--- a/src/llm-provider.ts
+++ b/src/llm-provider.ts
@@ -1,0 +1,740 @@
+/**
+ * LLM Provider using @anthropic-ai/claude-agent-sdk query() function.
+ *
+ * Converts SDK stream events into the SSE format expected by
+ * the claude-to-im bridge conversation engine.
+ */
+
+import fs from 'node:fs';
+import { execSync } from 'node:child_process';
+import { query } from '@anthropic-ai/claude-agent-sdk';
+import type { SDKMessage, PermissionResult } from '@anthropic-ai/claude-agent-sdk';
+import type { LLMProvider, StreamChatParams, FileAttachment } from 'claude-to-im/src/lib/bridge/host.js';
+import type { PendingPermissions } from './permission-gateway.js';
+
+import { sseEvent } from './sse-utils.js';
+
+// ── Environment isolation ──
+
+/** Env vars always passed through to the CLI subprocess. */
+const ENV_WHITELIST = new Set([
+  'PATH', 'HOME', 'USER', 'LOGNAME', 'SHELL',
+  'LANG', 'LC_ALL', 'LC_CTYPE',
+  'TMPDIR', 'TEMP', 'TMP',
+  'TERM', 'COLORTERM',
+  'NODE_PATH', 'NODE_EXTRA_CA_CERTS',
+  'XDG_CONFIG_HOME', 'XDG_DATA_HOME', 'XDG_CACHE_HOME',
+  'SSH_AUTH_SOCK',
+]);
+
+/** Prefixes that are always stripped (even in inherit mode). */
+const ENV_ALWAYS_STRIP = ['CLAUDECODE'];
+
+// ── Auth/credential-error detection ──
+
+/** Patterns indicating the local CLI is not logged in (fixable via `claude auth login`). */
+const CLI_AUTH_PATTERNS = [
+  /not logged in/i,
+  /please run \/login/i,
+  /loggedIn['":\s]*false/i,
+];
+
+/**
+ * Patterns indicating an API-level credential failure (wrong key, expired token, org restriction).
+ * Must be specific to API/auth context — avoid matching local file permissions, tool denials,
+ * or generic HTTP 403s that may have non-auth causes.
+ */
+const API_AUTH_PATTERNS = [
+  /unauthorized/i,
+  /invalid.*api.?key/i,
+  /authentication.*failed/i,
+  /does not have access/i,
+  /401\b/,
+];
+
+export type AuthErrorKind = 'cli' | 'api' | false;
+
+/**
+ * Classify an error message as a CLI login issue, an API credential issue, or neither.
+ * Returns 'cli' for local auth problems, 'api' for remote credential problems, false otherwise.
+ */
+export function classifyAuthError(text: string): AuthErrorKind {
+  if (CLI_AUTH_PATTERNS.some(re => re.test(text))) return 'cli';
+  if (API_AUTH_PATTERNS.some(re => re.test(text))) return 'api';
+  return false;
+}
+
+/** Backwards-compatible: returns true for any auth/credential error. */
+export function isAuthError(text: string): boolean {
+  return classifyAuthError(text) !== false;
+}
+
+const CLI_AUTH_USER_MESSAGE =
+  'Claude CLI is not logged in. Run `claude auth login`, then restart the bridge.';
+
+const API_AUTH_USER_MESSAGE =
+  'API credential error. Check your ANTHROPIC_API_KEY / ANTHROPIC_AUTH_TOKEN in config.env, ' +
+  'or verify your organization has access to the requested model.';
+
+// ── Cross-runtime model guard ──
+
+const NON_CLAUDE_MODEL_RE = /^(gpt-|o[1-9][-_]|codex[-_]|davinci|text-|openai\/)/i;
+
+/** Return true if a model name clearly belongs to a non-Claude provider. */
+export function isNonClaudeModel(model?: string): boolean {
+  return !!model && NON_CLAUDE_MODEL_RE.test(model);
+}
+
+/**
+ * Build a clean env for the CLI subprocess.
+ *
+ * CTI_ENV_ISOLATION (default "inherit"):
+ *   "inherit" — full parent env minus CLAUDECODE (recommended; daemon
+ *               already runs in a clean launchd/setsid environment)
+ *   "strict"  — only whitelist + CTI_* + ANTHROPIC_* from config.env
+ */
+export function buildSubprocessEnv(): Record<string, string> {
+  const mode = process.env.CTI_ENV_ISOLATION || 'inherit';
+  const out: Record<string, string> = {};
+
+  if (mode === 'inherit') {
+    // Pass everything except always-stripped vars
+    for (const [k, v] of Object.entries(process.env)) {
+      if (v === undefined) continue;
+      if (ENV_ALWAYS_STRIP.includes(k)) continue;
+      out[k] = v;
+    }
+  } else {
+    // Strict: whitelist only
+    for (const [k, v] of Object.entries(process.env)) {
+      if (v === undefined) continue;
+      if (ENV_WHITELIST.has(k)) { out[k] = v; continue; }
+      // Pass through CTI_* so skill config is available
+      if (k.startsWith('CTI_')) { out[k] = v; continue; }
+    }
+    // Always pass through ANTHROPIC_* in claude/auto runtime —
+    // third-party API providers need these to reach the CLI subprocess.
+    const runtime = process.env.CTI_RUNTIME || 'claude';
+    if (runtime === 'claude' || runtime === 'auto') {
+      for (const [k, v] of Object.entries(process.env)) {
+        if (v !== undefined && k.startsWith('ANTHROPIC_')) out[k] = v;
+      }
+    }
+
+    // In codex/auto mode, pass through OPENAI_* / CODEX_* env vars
+    if (runtime === 'codex' || runtime === 'auto') {
+      for (const [k, v] of Object.entries(process.env)) {
+        if (v !== undefined && (k.startsWith('OPENAI_') || k.startsWith('CODEX_'))) out[k] = v;
+      }
+    }
+  }
+
+  return out;
+}
+
+// ── Claude CLI preflight check ──
+
+/** Minimum major version of Claude CLI required by the SDK. */
+const MIN_CLI_MAJOR = 2;
+
+/**
+ * Parse a version string like "2.3.1" or "claude 2.3.1" into a major number.
+ * Returns undefined if parsing fails.
+ */
+export function parseCliMajorVersion(versionOutput: string): number | undefined {
+  const m = versionOutput.match(/(\d+)\.\d+/);
+  return m ? parseInt(m[1], 10) : undefined;
+}
+
+/**
+ * Run `claude --version` at a given path and return the version string.
+ * Returns undefined on failure.
+ */
+function getCliVersion(cliPath: string, env?: Record<string, string>): string | undefined {
+  try {
+    return execSync(`"${cliPath}" --version`, {
+      encoding: 'utf-8',
+      timeout: 10_000,
+      env: env || buildSubprocessEnv(),
+      stdio: ['pipe', 'pipe', 'pipe'],
+    }).trim();
+  } catch {
+    return undefined;
+  }
+}
+
+/**
+ * Flags that the SDK passes to the CLI subprocess.
+ * If `claude --help` doesn't mention these, the CLI build is incompatible.
+ */
+const REQUIRED_CLI_FLAGS = ['output-format', 'input-format', 'permission-mode', 'setting-sources'];
+
+/**
+ * Check `claude --help` for required flags.
+ * Returns the list of missing flags (empty = all present).
+ */
+function checkRequiredFlags(cliPath: string, env?: Record<string, string>): string[] {
+  let helpText: string;
+  try {
+    helpText = execSync(`"${cliPath}" --help`, {
+      encoding: 'utf-8',
+      timeout: 10_000,
+      env: env || buildSubprocessEnv(),
+      stdio: ['pipe', 'pipe', 'pipe'],
+    });
+  } catch {
+    // Can't run --help; don't block on this — version check is primary
+    return [];
+  }
+  return REQUIRED_CLI_FLAGS.filter(flag => !helpText.includes(flag));
+}
+
+/**
+ * Check if a CLI path points to a compatible (>= 2.x) Claude CLI
+ * with the required flags for SDK integration.
+ * Returns { compatible, version, ... } or undefined if the CLI cannot run at all.
+ */
+export function checkCliCompatibility(cliPath: string, env?: Record<string, string>): {
+  compatible: boolean;
+  version: string;
+  major: number | undefined;
+  missingFlags?: string[];
+} | undefined {
+  const version = getCliVersion(cliPath, env);
+  if (!version) return undefined;
+  const major = parseCliMajorVersion(version);
+  if (major === undefined || major < MIN_CLI_MAJOR) {
+    return { compatible: false, version, major };
+  }
+  // Version OK — verify required flags exist
+  const missing = checkRequiredFlags(cliPath, env);
+  return {
+    compatible: missing.length === 0,
+    version,
+    major,
+    missingFlags: missing.length > 0 ? missing : undefined,
+  };
+}
+
+/**
+ * Run a lightweight preflight check to verify the claude CLI can start
+ * and supports the flags required by the SDK.
+ * Returns { ok, version?, error? }.
+ */
+export function preflightCheck(cliPath: string): { ok: boolean; version?: string; error?: string } {
+  const cleanEnv = buildSubprocessEnv();
+  const compat = checkCliCompatibility(cliPath, cleanEnv);
+  if (!compat) {
+    return { ok: false, error: `claude CLI at "${cliPath}" failed to execute` };
+  }
+  if (compat.major !== undefined && compat.major < MIN_CLI_MAJOR) {
+    return {
+      ok: false,
+      version: compat.version,
+      error: `claude CLI version ${compat.version} is too old (need >= ${MIN_CLI_MAJOR}.x). ` +
+        `This is likely an npm-installed 1.x CLI. Install the native CLI: https://docs.anthropic.com/en/docs/claude-code`,
+    };
+  }
+  if (compat.missingFlags) {
+    return {
+      ok: false,
+      version: compat.version,
+      error: `claude CLI ${compat.version} is missing required flags: ${compat.missingFlags.join(', ')}. ` +
+        `Update the CLI: npm update -g @anthropic-ai/claude-code`,
+    };
+  }
+  return { ok: true, version: compat.version };
+}
+
+// ── Claude CLI path resolution ──
+
+function isExecutable(p: string): boolean {
+  try {
+    fs.accessSync(p, fs.constants.X_OK);
+    return true;
+  } catch {
+    return false;
+  }
+}
+
+/**
+ * Resolve all `claude` executables found in PATH (Unix only).
+ * Returns an array of absolute paths.
+ */
+function findAllInPath(): string[] {
+  if (process.platform === 'win32') {
+    try {
+      return execSync('where claude', { encoding: 'utf-8', timeout: 3000 })
+        .trim().split('\n').map(s => s.trim()).filter(Boolean);
+    } catch { return []; }
+  }
+  try {
+    // `which -a` lists all matches, not just the first
+    return execSync('which -a claude', { encoding: 'utf-8', timeout: 3000 })
+      .trim().split('\n').map(s => s.trim()).filter(Boolean);
+  } catch { return []; }
+}
+
+/**
+ * Resolve the path to the `claude` CLI executable.
+ *
+ * Priority:
+ *   1. CTI_CLAUDE_CODE_EXECUTABLE env var (explicit override)
+ *   2. All `claude` executables in PATH — pick first compatible (>= 2.x)
+ *   3. Common install locations — pick first compatible (>= 2.x)
+ *
+ * This multi-candidate approach handles the common scenario where
+ * nvm/npm puts an old 1.x claude in PATH before the native 2.x CLI.
+ */
+export function resolveClaudeCliPath(): string | undefined {
+  // 1. Explicit env var — trust the user
+  const fromEnv = process.env.CTI_CLAUDE_CODE_EXECUTABLE;
+  if (fromEnv && isExecutable(fromEnv)) return fromEnv;
+
+  // 2. Gather all candidates
+  const isWindows = process.platform === 'win32';
+  const pathCandidates = findAllInPath();
+  const wellKnown = isWindows
+    ? [
+        process.env.LOCALAPPDATA ? `${process.env.LOCALAPPDATA}\\Programs\\claude\\claude.exe` : '',
+        'C:\\Program Files\\claude\\claude.exe',
+      ].filter(Boolean)
+    : [
+        `${process.env.HOME}/.claude/local/claude`,
+        `${process.env.HOME}/.local/bin/claude`,
+        '/usr/local/bin/claude',
+        '/opt/homebrew/bin/claude',
+        `${process.env.HOME}/.npm-global/bin/claude`,
+      ];
+
+  // Deduplicate while preserving order
+  const seen = new Set<string>();
+  const allCandidates: string[] = [];
+  for (const p of [...pathCandidates, ...wellKnown]) {
+    if (p && !seen.has(p)) {
+      seen.add(p);
+      allCandidates.push(p);
+    }
+  }
+
+  // 3. Pick the first compatible candidate
+  let firstUnverifiable: string | undefined;
+  for (const p of allCandidates) {
+    if (!isExecutable(p)) continue;
+
+    const compat = checkCliCompatibility(p);
+    if (compat?.compatible) {
+      if (p !== pathCandidates[0] && pathCandidates.length > 0) {
+        console.log(`[llm-provider] Skipping incompatible CLI at "${pathCandidates[0]}", using "${p}" (${compat.version})`);
+      }
+      return p;
+    }
+    if (compat) {
+      // Version detected but too old — skip it entirely, do NOT fall back
+      console.warn(`[llm-provider] CLI at "${p}" is version ${compat.version} (need >= ${MIN_CLI_MAJOR}.x), skipping`);
+    } else if (!firstUnverifiable) {
+      // Executable exists but --version failed (timeout, crash, etc.)
+      // Keep as last-resort fallback only if NO candidate had a parseable version
+      firstUnverifiable = p;
+    }
+  }
+
+  // Only fall back to an unverifiable executable — never to a known-old one.
+  // This avoids silently using a 1.x CLI that will crash on first message.
+  return firstUnverifiable;
+}
+
+// ── Multi-modal prompt builder ──
+
+type ImageMediaType = 'image/png' | 'image/jpeg' | 'image/gif' | 'image/webp';
+
+const SUPPORTED_IMAGE_TYPES = new Set<string>([
+  'image/png', 'image/jpeg', 'image/jpg', 'image/gif', 'image/webp',
+]);
+
+/**
+ * Build a prompt for query(). When files are present, returns an async
+ * iterable that yields a single SDKUserMessage with multi-modal content
+ * (image blocks + text). Otherwise returns the plain text string.
+ */
+function buildPrompt(
+  text: string,
+  files?: FileAttachment[],
+): string | AsyncIterable<{ type: 'user'; message: { role: 'user'; content: unknown[] }; parent_tool_use_id: null; session_id: string }> {
+  // Separate image files (multi-modal) from non-image files (path injection)
+  const imageFiles = files?.filter(f => SUPPORTED_IMAGE_TYPES.has(f.type)) ?? [];
+  const nonImageFiles = files?.filter(f => !SUPPORTED_IMAGE_TYPES.has(f.type)) ?? [];
+
+  // For non-image files (PDF, CSV, etc.), inject file paths into the prompt
+  // so Claude can read them with the Read tool.
+  let augmentedText = text;
+  if (nonImageFiles.length > 0) {
+    const fileList = nonImageFiles
+      .filter(f => f.filePath)
+      .map(f => `- ${f.filePath} (${f.name}, ${f.type})`)
+      .join('\n');
+    if (fileList) {
+      const prefix = `The user sent the following file(s). Read them with the Read tool to see their contents:\n${fileList}\n\n`;
+      augmentedText = prefix + (text || 'Please read and analyze the attached file(s).');
+    }
+  }
+
+  if (imageFiles.length === 0) return augmentedText;
+
+  const contentBlocks: unknown[] = [];
+
+  for (const file of imageFiles) {
+    contentBlocks.push({
+      type: 'image',
+      source: {
+        type: 'base64',
+        media_type: (file.type === 'image/jpg' ? 'image/jpeg' : file.type) as ImageMediaType,
+        data: file.data,
+      },
+    });
+  }
+
+  if (augmentedText.trim()) {
+    contentBlocks.push({ type: 'text', text: augmentedText });
+  }
+
+  const msg = {
+    type: 'user' as const,
+    message: { role: 'user' as const, content: contentBlocks },
+    parent_tool_use_id: null,
+    session_id: '',
+  };
+
+  return (async function* () { yield msg; })();
+}
+
+/**
+ * Mutable state shared between the streaming loop and catch block.
+ *
+ * Key distinction:
+ *   hasReceivedResult — set when the SDK delivers a `result` message
+ *     (success OR structured error). This means the CLI completed its
+ *     business logic; any subsequent "process exited with code 1" is
+ *     just the transport tearing down and should be suppressed.
+ *
+ *   hasStreamedText — set when at least one text_delta was emitted.
+ *     Used to distinguish "partial output + crash" (real failure, must
+ *     emit error) from "business error only in assistant block" (use
+ *     lastAssistantText instead of generic error).
+ */
+export interface StreamState {
+  /** True once a `result` message (success or error subtype) has been processed. */
+  hasReceivedResult: boolean;
+  /** True once any text_delta has been emitted via stream_event. */
+  hasStreamedText: boolean;
+  /**
+   * Full text captured from the final `assistant` message.
+   * NOT emitted during normal flow (stream_event deltas handle that).
+   * Used by the catch block to surface business errors that arrived
+   * as assistant text but were followed by a CLI crash.
+   */
+  lastAssistantText: string;
+}
+
+export class SDKLLMProvider implements LLMProvider {
+  private cliPath: string | undefined;
+  private autoApprove: boolean;
+
+  constructor(private pendingPerms: PendingPermissions, cliPath?: string, autoApprove = false) {
+    this.cliPath = cliPath;
+    this.autoApprove = autoApprove;
+  }
+
+  streamChat(params: StreamChatParams): ReadableStream<string> {
+    const pendingPerms = this.pendingPerms;
+    const cliPath = this.cliPath;
+    const autoApprove = this.autoApprove;
+
+    return new ReadableStream({
+      start(controller) {
+        (async () => {
+          // Ring-buffer for recent stderr output (max 4 KB)
+          const MAX_STDERR = 4096;
+          let stderrBuf = '';
+          const state: StreamState = { hasReceivedResult: false, hasStreamedText: false, lastAssistantText: '' };
+
+          try {
+            const cleanEnv = buildSubprocessEnv();
+
+            // Cross-runtime migration safety: drop non-Claude model names
+            // that may linger in session data from a previous Codex runtime.
+            let model = params.model;
+            if (isNonClaudeModel(model)) {
+              console.warn(`[llm-provider] Ignoring non-Claude model "${model}", using CLI default`);
+              model = undefined;
+            }
+
+            // Only pass model to CLI if explicitly configured via CTI_DEFAULT_MODEL.
+            // Letting the CLI choose its own default avoids exit-code-1 failures
+            // when a stored model is inaccessible on the current machine/plan.
+            const passModel = !!process.env.CTI_DEFAULT_MODEL;
+            if (model && !passModel) {
+              console.log(`[llm-provider] Skipping model "${model}", using CLI default (set CTI_DEFAULT_MODEL to override)`);
+              model = undefined;
+            }
+
+            const queryOptions: Record<string, unknown> = {
+              cwd: params.workingDirectory,
+              model,
+              resume: params.sdkSessionId || undefined,
+              abortController: params.abortController,
+              permissionMode: (params.permissionMode as 'default' | 'acceptEdits' | 'plan') || undefined,
+              includePartialMessages: true,
+              env: cleanEnv,
+              stderr: (data: string) => {
+                stderrBuf += data;
+                if (stderrBuf.length > MAX_STDERR) {
+                  stderrBuf = stderrBuf.slice(-MAX_STDERR);
+                }
+              },
+              canUseTool: async (
+                  toolName: string,
+                  input: Record<string, unknown>,
+                  opts: { toolUseID: string; suggestions?: string[] },
+                ): Promise<PermissionResult> => {
+                  // Auto-approve if configured (useful for channels without
+                  // interactive permission UI, e.g. Feishu WebSocket mode)
+                  if (autoApprove) {
+                    return { behavior: 'allow' as const, updatedInput: input };
+                  }
+
+                  // Emit permission_request SSE event for the bridge
+                  controller.enqueue(
+                    sseEvent('permission_request', {
+                      permissionRequestId: opts.toolUseID,
+                      toolName,
+                      toolInput: input,
+                      suggestions: opts.suggestions || [],
+                    }),
+                  );
+
+                  // Block until IM user responds
+                  const result = await pendingPerms.waitFor(opts.toolUseID);
+
+                  if (result.behavior === 'allow') {
+                    return { behavior: 'allow' as const, updatedInput: input };
+                  }
+                  return {
+                    behavior: 'deny' as const,
+                    message: result.message || 'Denied by user',
+                  };
+                },
+            };
+            if (cliPath) {
+              queryOptions.pathToClaudeCodeExecutable = cliPath;
+            }
+
+            const prompt = buildPrompt(params.prompt, params.files);
+            const q = query({
+              prompt: prompt as Parameters<typeof query>[0]['prompt'],
+              options: queryOptions as Parameters<typeof query>[0]['options'],
+            });
+
+            for await (const msg of q) {
+              handleMessage(msg, controller, state);
+            }
+
+            controller.close();
+          } catch (err) {
+            const message = err instanceof Error ? err.message : String(err);
+            console.error('[llm-provider] SDK query error:', err instanceof Error ? err.stack || err.message : err);
+            if (stderrBuf) {
+              console.error('[llm-provider] stderr from CLI:', stderrBuf.trim());
+            }
+
+            const isTransportExit = message.includes('process exited with code');
+
+            // ── Case 1: Result already received ──
+            // The SDK delivered a proper result (success or structured error).
+            // A trailing "process exited with code 1" is transport teardown noise.
+            if (state.hasReceivedResult && isTransportExit) {
+              console.log('[llm-provider] Suppressing transport error — result already received');
+              controller.close();
+              return;
+            }
+
+            // ── Case 2: Recognised business error in assistant text ──
+            // The CLI returned an assistant message with text that matches
+            // a known auth/access error pattern (e.g. "Your organization
+            // does not have access to Claude"). Forward it as-is — it's
+            // more informative than the generic transport error.
+            // Only activate when the text is a recognised error; otherwise
+            // a normal response that crashed before result would be silently
+            // presented as if it succeeded.
+            if (state.lastAssistantText && classifyAuthError(state.lastAssistantText)) {
+              controller.enqueue(sseEvent('text', state.lastAssistantText));
+              controller.close();
+              return;
+            }
+
+            // ── Case 3: Partial output + crash ──
+            // Text was streamed but no result arrived — the response was
+            // truncated by a real crash. Always emit an error so the user
+            // knows the output is incomplete.
+
+            // ── Build user-facing error message ──
+            const authKind = classifyAuthError(message) || classifyAuthError(stderrBuf);
+            let userMessage: string;
+            if (authKind === 'cli') {
+              userMessage = CLI_AUTH_USER_MESSAGE;
+            } else if (authKind === 'api') {
+              userMessage = API_AUTH_USER_MESSAGE;
+            } else if (isTransportExit) {
+              const stderrSummary = stderrBuf.trim();
+              const lines = [message];
+              if (stderrSummary) {
+                lines.push('', 'CLI stderr:', stderrSummary.slice(-1024));
+              }
+              lines.push(
+                '',
+                'Possible causes:',
+                '• Claude CLI not authenticated — run: claude auth login',
+                '• Claude CLI version too old (need >= 2.x) — run: claude --version',
+                '• Missing ANTHROPIC_* env vars in daemon — check config.env',
+                '',
+                'Run `/claude-to-im doctor` to diagnose.',
+              );
+              userMessage = lines.join('\n');
+            } else {
+              userMessage = message;
+            }
+
+            controller.enqueue(sseEvent('error', userMessage));
+            controller.close();
+          }
+        })();
+      },
+    });
+  }
+}
+
+/** @internal Exported for testing. */
+export function handleMessage(
+  msg: SDKMessage,
+  controller: ReadableStreamDefaultController<string>,
+  state: StreamState,
+): void {
+  switch (msg.type) {
+    case 'stream_event': {
+      const event = msg.event;
+      if (
+        event.type === 'content_block_delta' &&
+        event.delta.type === 'text_delta'
+      ) {
+        // Emit delta text — the bridge accumulates on its side
+        controller.enqueue(sseEvent('text', event.delta.text));
+        state.hasStreamedText = true;
+      }
+      if (
+        event.type === 'content_block_start' &&
+        event.content_block.type === 'tool_use'
+      ) {
+        controller.enqueue(
+          sseEvent('tool_use', {
+            id: event.content_block.id,
+            name: event.content_block.name,
+            input: {},
+          }),
+        );
+      }
+      break;
+    }
+
+    case 'assistant': {
+      // Full assistant message — capture text but do NOT emit it.
+      // Text deltas are already streamed via stream_event above; emitting
+      // the full text block here would duplicate the entire response.
+      //
+      // The captured text is used by the catch block to surface business
+      // errors (e.g. "Your organization does not have access") that the
+      // CLI returned as assistant text without prior streaming deltas.
+      if (msg.message?.content) {
+        for (const block of msg.message.content) {
+          if (block.type === 'text' && block.text) {
+            state.lastAssistantText += (state.lastAssistantText ? '\n' : '') + block.text;
+          } else if (block.type === 'tool_use') {
+            controller.enqueue(
+              sseEvent('tool_use', {
+                id: block.id,
+                name: block.name,
+                input: block.input,
+              }),
+            );
+          }
+        }
+      }
+      break;
+    }
+
+    case 'user': {
+      // User messages contain tool_result blocks from completed tool calls
+      const content = msg.message?.content;
+      if (Array.isArray(content)) {
+        for (const block of content) {
+          if (typeof block === 'object' && block !== null && 'type' in block && block.type === 'tool_result') {
+            const rb = block as { tool_use_id: string; content?: unknown; is_error?: boolean };
+            const text = typeof rb.content === 'string'
+              ? rb.content
+              : JSON.stringify(rb.content ?? '');
+            controller.enqueue(
+              sseEvent('tool_result', {
+                tool_use_id: rb.tool_use_id,
+                content: text,
+                is_error: rb.is_error || false,
+              }),
+            );
+          }
+        }
+      }
+      break;
+    }
+
+    case 'result': {
+      state.hasReceivedResult = true;
+      if (msg.subtype === 'success') {
+        controller.enqueue(
+          sseEvent('result', {
+            session_id: msg.session_id,
+            is_error: msg.is_error,
+            usage: {
+              input_tokens: msg.usage.input_tokens,
+              output_tokens: msg.usage.output_tokens,
+              cache_read_input_tokens: msg.usage.cache_read_input_tokens ?? 0,
+              cache_creation_input_tokens: msg.usage.cache_creation_input_tokens ?? 0,
+              cost_usd: msg.total_cost_usd,
+            },
+          }),
+        );
+      } else {
+        // Error result from SDK (distinct from transport errors in catch)
+        const errors =
+          'errors' in msg && Array.isArray(msg.errors)
+            ? msg.errors.join('; ')
+            : 'Unknown error';
+        controller.enqueue(sseEvent('error', errors));
+      }
+      break;
+    }
+
+    case 'system': {
+      if (msg.subtype === 'init') {
+        controller.enqueue(
+          sseEvent('status', {
+            session_id: msg.session_id,
+            model: msg.model,
+          }),
+        );
+      }
+      break;
+    }
+
+    default:
+      // Ignore other message types (auth_status, task_notification, etc.)
+      break;
+  }
+}

--- a/src/llm-provider.ts
+++ b/src/llm-provider.ts
@@ -10,6 +10,7 @@ import { execSync } from 'node:child_process';
 import { query } from '@anthropic-ai/claude-agent-sdk';
 import type { SDKMessage, PermissionResult } from '@anthropic-ai/claude-agent-sdk';
 import type { LLMProvider, StreamChatParams, FileAttachment } from 'claude-to-im/src/lib/bridge/host.js';
+import { getBridgeContext } from './lib/bridge/context.js';
 import type { PendingPermissions } from './permission-gateway.js';
 
 import { sseEvent } from './sse-utils.js';
@@ -505,6 +506,15 @@ export class SDKLLMProvider implements LLMProvider {
               console.log(
                 `[llm-provider] Spawning CC with sender: channel=${params.senderChannel || '-'} user_id=${params.senderUserId || '-'} name=${params.senderName || '-'}`,
               );
+            }
+
+            // Per-bot lark-cli identity isolation.
+            if (params.botName) {
+              const ctx = getBridgeContext();
+              const botConfig = ctx.feishuBotConfigs?.find(b => b.name === params.botName);
+              if (botConfig?.larkCliConfigDir) {
+                cleanEnv.LARKSUITE_CLI_CONFIG_DIR = botConfig.larkCliConfigDir;
+              }
             }
 
             // Cross-runtime migration safety: drop non-Claude model names

--- a/src/llm-provider.ts
+++ b/src/llm-provider.ts
@@ -358,9 +358,21 @@ const SUPPORTED_IMAGE_TYPES = new Set<string>([
  * iterable that yields a single SDKUserMessage with multi-modal content
  * (image blocks + text). Otherwise returns the plain text string.
  */
+interface SenderContext {
+  channel?: string;
+  userId?: string;
+  name?: string;
+}
+
+/** Escape double quotes so the XML attribute stays well-formed. */
+function xmlAttr(s: string): string {
+  return s.replace(/&/g, '&amp;').replace(/"/g, '&quot;').replace(/</g, '&lt;').replace(/>/g, '&gt;');
+}
+
 function buildPrompt(
   text: string,
   files?: FileAttachment[],
+  sender?: SenderContext,
 ): string | AsyncIterable<{ type: 'user'; message: { role: 'user'; content: unknown[] }; parent_tool_use_id: null; session_id: string }> {
   // Separate image files (multi-modal) from non-image files (path injection)
   const imageFiles = files?.filter(f => SUPPORTED_IMAGE_TYPES.has(f.type)) ?? [];
@@ -378,6 +390,18 @@ function buildPrompt(
       const prefix = `The user sent the following file(s). Read them with the Read tool to see their contents:\n${fileList}\n\n`;
       augmentedText = prefix + (text || 'Please read and analyze the attached file(s).');
     }
+  }
+
+  // Prepend a system-controlled sender header so CC knows exactly who is talking.
+  // User-typed `<cti-sender .../>` cannot spoof this because the header is emitted
+  // by the bridge, not the user, and CC is instructed to trust only the first tag.
+  if (sender?.userId || sender?.channel) {
+    const parts: string[] = [];
+    if (sender.channel) parts.push(`channel="${xmlAttr(sender.channel)}"`);
+    if (sender.userId) parts.push(`user_id="${xmlAttr(sender.userId)}"`);
+    if (sender.name) parts.push(`name="${xmlAttr(sender.name)}"`);
+    const header = `<cti-sender ${parts.join(' ')}/>\n\n`;
+    augmentedText = header + augmentedText;
   }
 
   if (imageFiles.length === 0) return augmentedText;
@@ -461,8 +485,27 @@ export class SDKLLMProvider implements LLMProvider {
           let stderrBuf = '';
           const state: StreamState = { hasReceivedResult: false, hasStreamedText: false, toolNames: new Map(), lastAssistantText: '' };
 
+          // Overall timeout: abort if CC subprocess exceeds time limit (default 10 min)
+          const CC_MAX_TIMEOUT_MS = parseInt(process.env.CTI_CC_MAX_TIMEOUT_MS || '', 10) || 600_000;
+          const overallTimer = setTimeout(() => {
+            console.warn(`[llm-provider] CC subprocess exceeded ${CC_MAX_TIMEOUT_MS / 1000}s total timeout, aborting`);
+            params.abortController?.abort();
+          }, CC_MAX_TIMEOUT_MS);
+
           try {
             const cleanEnv = buildSubprocessEnv();
+
+            // Inject IM sender identity so the spawned CC session can route
+            // per-user actions (e.g. picking the correct Obsidian vault).
+            // These override any same-named keys from the parent env.
+            if (params.senderChannel) cleanEnv.CTI_SENDER_CHANNEL = params.senderChannel;
+            if (params.senderUserId) cleanEnv.CTI_SENDER_USER_ID = params.senderUserId;
+            if (params.senderName) cleanEnv.CTI_SENDER_NAME = params.senderName;
+            if (params.senderUserId || params.senderChannel) {
+              console.log(
+                `[llm-provider] Spawning CC with sender: channel=${params.senderChannel || '-'} user_id=${params.senderUserId || '-'} name=${params.senderName || '-'}`,
+              );
+            }
 
             // Cross-runtime migration safety: drop non-Claude model names
             // that may linger in session data from a previous Codex runtime.
@@ -532,7 +575,11 @@ export class SDKLLMProvider implements LLMProvider {
               queryOptions.pathToClaudeCodeExecutable = cliPath;
             }
 
-            const prompt = buildPrompt(params.prompt, params.files);
+            const prompt = buildPrompt(params.prompt, params.files, {
+              channel: params.senderChannel,
+              userId: params.senderUserId,
+              name: params.senderName,
+            });
             const q = query({
               prompt: prompt as Parameters<typeof query>[0]['prompt'],
               options: queryOptions as Parameters<typeof query>[0]['options'],
@@ -542,8 +589,10 @@ export class SDKLLMProvider implements LLMProvider {
               handleMessage(msg, controller, state);
             }
 
+            clearTimeout(overallTimer);
             controller.close();
           } catch (err) {
+            clearTimeout(overallTimer);
             const message = err instanceof Error ? err.message : String(err);
             console.error('[llm-provider] SDK query error:', err instanceof Error ? err.stack || err.message : err);
             if (stderrBuf) {

--- a/src/logger.ts
+++ b/src/logger.ts
@@ -1,0 +1,79 @@
+import fs from 'node:fs';
+import path from 'node:path';
+import { CTI_HOME } from './config.js';
+
+const MASK_PATTERNS: RegExp[] = [
+  /(?:token|secret|password|api_key)["']?\s*[:=]\s*["']?([^\s"',]+)/gi,
+  /bot\d+:[A-Za-z0-9_-]{35}/g,
+  /Bearer\s+[A-Za-z0-9._-]+/g,
+];
+
+export function maskSecrets(text: string): string {
+  let result = text;
+  for (const pattern of MASK_PATTERNS) {
+    pattern.lastIndex = 0;
+    result = result.replace(pattern, (match) => {
+      if (match.length <= 4) return match;
+      return '*'.repeat(match.length - 4) + match.slice(-4);
+    });
+  }
+  return result;
+}
+
+const LOG_DIR = path.join(CTI_HOME, 'logs');
+const LOG_PATH = path.join(LOG_DIR, 'bridge.log');
+const MAX_LOG_SIZE = 10 * 1024 * 1024; // 10MB
+const MAX_ROTATED = 3;
+
+let logStream: fs.WriteStream | null = null;
+
+function openLogStream(): fs.WriteStream {
+  return fs.createWriteStream(LOG_PATH, { flags: 'a' });
+}
+
+function rotateIfNeeded(): void {
+  try {
+    const stat = fs.statSync(LOG_PATH);
+    if (stat.size < MAX_LOG_SIZE) return;
+  } catch {
+    return; // file doesn't exist yet
+  }
+
+  // Close current stream
+  if (logStream) {
+    logStream.end();
+    logStream = null;
+  }
+
+  // Rotate: delete .3, shift .2→.3, .1→.2, current→.1
+  const path3 = `${LOG_PATH}.${MAX_ROTATED}`;
+  if (fs.existsSync(path3)) fs.unlinkSync(path3);
+
+  for (let i = MAX_ROTATED - 1; i >= 1; i--) {
+    const src = `${LOG_PATH}.${i}`;
+    const dst = `${LOG_PATH}.${i + 1}`;
+    if (fs.existsSync(src)) fs.renameSync(src, dst);
+  }
+
+  fs.renameSync(LOG_PATH, `${LOG_PATH}.1`);
+  logStream = openLogStream();
+}
+
+export function setupLogger(): void {
+  fs.mkdirSync(LOG_DIR, { recursive: true });
+  logStream = openLogStream();
+
+  const write = (level: string, args: unknown[]) => {
+    const timestamp = new Date().toISOString();
+    const message = args.map((a) => (typeof a === 'string' ? a : JSON.stringify(a))).join(' ');
+    const formatted = `[${timestamp}] [${level}] ${message}`;
+    const masked = maskSecrets(formatted);
+
+    rotateIfNeeded();
+    logStream?.write(masked + '\n');
+  };
+
+  console.log = (...args: unknown[]) => write('INFO', args);
+  console.error = (...args: unknown[]) => write('ERROR', args);
+  console.warn = (...args: unknown[]) => write('WARN', args);
+}

--- a/src/main.ts
+++ b/src/main.ts
@@ -1,0 +1,207 @@
+/**
+ * Daemon entry point for claude-to-im-skill.
+ *
+ * Assembles all DI implementations and starts the bridge.
+ */
+
+import fs from 'node:fs';
+import path from 'node:path';
+import crypto from 'node:crypto';
+
+import { initBridgeContext } from 'claude-to-im/src/lib/bridge/context.js';
+import * as bridgeManager from 'claude-to-im/src/lib/bridge/bridge-manager.js';
+// Side-effect import to trigger adapter self-registration
+import 'claude-to-im/src/lib/bridge/adapters/index.js';
+import './adapters/weixin-adapter.js';
+
+import type { LLMProvider } from 'claude-to-im/src/lib/bridge/host.js';
+import { loadConfig, configToSettings, CTI_HOME } from './config.js';
+import type { Config } from './config.js';
+import { JsonFileStore } from './store.js';
+import { SDKLLMProvider, resolveClaudeCliPath, preflightCheck } from './llm-provider.js';
+import { PendingPermissions } from './permission-gateway.js';
+import { setupLogger } from './logger.js';
+
+const RUNTIME_DIR = path.join(CTI_HOME, 'runtime');
+const STATUS_FILE = path.join(RUNTIME_DIR, 'status.json');
+const PID_FILE = path.join(RUNTIME_DIR, 'bridge.pid');
+
+/**
+ * Resolve the LLM provider based on the runtime setting.
+ * - 'claude' (default): uses Claude Code SDK via SDKLLMProvider
+ * - 'codex': uses @openai/codex-sdk via CodexProvider
+ * - 'auto': tries Claude first, falls back to Codex
+ */
+async function resolveProvider(config: Config, pendingPerms: PendingPermissions): Promise<LLMProvider> {
+  const runtime = config.runtime;
+
+  if (runtime === 'codex') {
+    const { CodexProvider } = await import('./codex-provider.js');
+    return new CodexProvider(pendingPerms);
+  }
+
+  if (runtime === 'auto') {
+    const cliPath = resolveClaudeCliPath();
+    if (cliPath) {
+      // Auto mode: preflight the resolved CLI before committing to it.
+      const check = preflightCheck(cliPath);
+      if (check.ok) {
+        console.log(`[claude-to-im] Auto: using Claude CLI at ${cliPath} (${check.version})`);
+        return new SDKLLMProvider(pendingPerms, cliPath, config.autoApprove);
+      }
+      // Preflight failed — fall through to Codex instead of silently using a broken CLI
+      console.warn(
+        `[claude-to-im] Auto: Claude CLI at ${cliPath} failed preflight: ${check.error}\n` +
+        `  Falling back to Codex.`,
+      );
+    } else {
+      console.log('[claude-to-im] Auto: Claude CLI not found, falling back to Codex');
+    }
+    const { CodexProvider } = await import('./codex-provider.js');
+    return new CodexProvider(pendingPerms);
+  }
+
+  // Default: claude
+  const cliPath = resolveClaudeCliPath();
+  if (!cliPath) {
+    console.error(
+      '[claude-to-im] FATAL: Cannot find the `claude` CLI executable.\n' +
+      '  Tried: CTI_CLAUDE_CODE_EXECUTABLE env, /usr/local/bin/claude, /opt/homebrew/bin/claude, ~/.npm-global/bin/claude, ~/.local/bin/claude\n' +
+      '  Fix: Install Claude Code CLI (https://docs.anthropic.com/en/docs/claude-code) or set CTI_CLAUDE_CODE_EXECUTABLE=/path/to/claude\n' +
+      '  Or: Set CTI_RUNTIME=codex to use Codex instead',
+    );
+    process.exit(1);
+  }
+
+  // Preflight: verify the CLI can actually run in the daemon environment.
+  // In claude runtime this is fatal — starting with a broken CLI would just
+  // defer the error to the first user message, which is harder to diagnose.
+  const check = preflightCheck(cliPath);
+  if (check.ok) {
+    console.log(`[claude-to-im] CLI preflight OK: ${cliPath} (${check.version})`);
+  } else {
+    console.error(
+      `[claude-to-im] FATAL: Claude CLI preflight check failed.\n` +
+      `  Path: ${cliPath}\n` +
+      `  Error: ${check.error}\n` +
+      `  Fix:\n` +
+      `    1. Install Claude Code CLI >= 2.x: https://docs.anthropic.com/en/docs/claude-code\n` +
+      `    2. Or set CTI_CLAUDE_CODE_EXECUTABLE=/path/to/correct/claude\n` +
+      `    3. Or set CTI_RUNTIME=auto to fall back to Codex`,
+    );
+    process.exit(1);
+  }
+
+  return new SDKLLMProvider(pendingPerms, cliPath, config.autoApprove);
+}
+
+interface StatusInfo {
+  running: boolean;
+  pid?: number;
+  runId?: string;
+  startedAt?: string;
+  channels?: string[];
+  lastExitReason?: string;
+}
+
+function writeStatus(info: StatusInfo): void {
+  fs.mkdirSync(RUNTIME_DIR, { recursive: true });
+  // Merge with existing status to preserve fields like lastExitReason
+  let existing: Record<string, unknown> = {};
+  try { existing = JSON.parse(fs.readFileSync(STATUS_FILE, 'utf-8')); } catch { /* first write */ }
+  const merged = { ...existing, ...info };
+  const tmp = STATUS_FILE + '.tmp';
+  fs.writeFileSync(tmp, JSON.stringify(merged, null, 2), 'utf-8');
+  fs.renameSync(tmp, STATUS_FILE);
+}
+
+async function main(): Promise<void> {
+  const config = loadConfig();
+  setupLogger();
+
+  const runId = crypto.randomUUID();
+  console.log(`[claude-to-im] Starting bridge (run_id: ${runId})`);
+
+  const settings = configToSettings(config);
+  const store = new JsonFileStore(settings);
+  const pendingPerms = new PendingPermissions();
+  const llm = await resolveProvider(config, pendingPerms);
+  console.log(`[claude-to-im] Runtime: ${config.runtime}`);
+
+  const gateway = {
+    resolvePendingPermission: (id: string, resolution: { behavior: 'allow' | 'deny'; message?: string }) =>
+      pendingPerms.resolve(id, resolution),
+  };
+
+  initBridgeContext({
+    store,
+    llm,
+    permissions: gateway,
+    lifecycle: {
+      onBridgeStart: () => {
+        // Write authoritative PID from the actual process (not shell $!)
+        fs.mkdirSync(RUNTIME_DIR, { recursive: true });
+        fs.writeFileSync(PID_FILE, String(process.pid), 'utf-8');
+        writeStatus({
+          running: true,
+          pid: process.pid,
+          runId,
+          startedAt: new Date().toISOString(),
+          channels: config.enabledChannels,
+        });
+        console.log(`[claude-to-im] Bridge started (PID: ${process.pid}, channels: ${config.enabledChannels.join(', ')})`);
+      },
+      onBridgeStop: () => {
+        writeStatus({ running: false });
+        console.log('[claude-to-im] Bridge stopped');
+      },
+    },
+  });
+
+  await bridgeManager.start();
+
+  // Graceful shutdown
+  let shuttingDown = false;
+  const shutdown = async (signal?: string) => {
+    if (shuttingDown) return;
+    shuttingDown = true;
+    const reason = signal ? `signal: ${signal}` : 'shutdown requested';
+    console.log(`[claude-to-im] Shutting down (${reason})...`);
+    pendingPerms.denyAll();
+    await bridgeManager.stop();
+    writeStatus({ running: false, lastExitReason: reason });
+    process.exit(0);
+  };
+
+  process.on('SIGTERM', () => shutdown('SIGTERM'));
+  process.on('SIGINT', () => shutdown('SIGINT'));
+  process.on('SIGHUP', () => shutdown('SIGHUP'));
+
+  // ── Exit diagnostics ──
+  process.on('unhandledRejection', (reason) => {
+    console.error('[claude-to-im] unhandledRejection:', reason instanceof Error ? reason.stack || reason.message : reason);
+    writeStatus({ running: false, lastExitReason: `unhandledRejection: ${reason instanceof Error ? reason.message : String(reason)}` });
+  });
+  process.on('uncaughtException', (err) => {
+    console.error('[claude-to-im] uncaughtException:', err.stack || err.message);
+    writeStatus({ running: false, lastExitReason: `uncaughtException: ${err.message}` });
+    process.exit(1);
+  });
+  process.on('beforeExit', (code) => {
+    console.log(`[claude-to-im] beforeExit (code: ${code})`);
+  });
+  process.on('exit', (code) => {
+    console.log(`[claude-to-im] exit (code: ${code})`);
+  });
+
+  // ── Heartbeat to keep event loop alive ──
+  // setInterval is ref'd by default, preventing Node from exiting
+  // when the event loop would otherwise be empty.
+  setInterval(() => { /* keepalive */ }, 45_000);
+}
+
+main().catch((err) => {
+  console.error('[claude-to-im] Fatal error:', err instanceof Error ? err.stack || err.message : err);
+  try { writeStatus({ running: false, lastExitReason: `fatal: ${err instanceof Error ? err.message : String(err)}` }); } catch { /* ignore */ }
+  process.exit(1);
+});

--- a/src/main.ts
+++ b/src/main.ts
@@ -21,6 +21,7 @@ import { JsonFileStore } from './store.js';
 import { SDKLLMProvider, resolveClaudeCliPath, preflightCheck } from './llm-provider.js';
 import { PendingPermissions } from './permission-gateway.js';
 import { setupLogger } from './logger.js';
+import { initContentGuard } from 'content-guard';
 
 const RUNTIME_DIR = path.join(CTI_HOME, 'runtime');
 const STATUS_FILE = path.join(RUNTIME_DIR, 'status.json');
@@ -121,6 +122,19 @@ async function main(): Promise<void> {
 
   const runId = crypto.randomUUID();
   console.log(`[claude-to-im] Starting bridge (run_id: ${runId})`);
+
+  // Initialize content guard (prompt injection detection)
+  initContentGuard({
+    enabled: config.injectionGuardEnabled,
+    minimaxApiKey: config.minimaxApiKey,
+    minimaxBaseUrl: config.minimaxBaseUrl,
+    minimaxModel: config.minimaxModel,
+    blockThreshold: config.injectionBlockThreshold,
+  });
+  console.log(
+    `[claude-to-im] Content guard: ${config.injectionGuardEnabled !== false ? 'enabled' : 'disabled'}` +
+    (config.minimaxApiKey ? ', LLM classifier: ready' : ', LLM classifier: no API key'),
+  );
 
   const settings = configToSettings(config);
   const store = new JsonFileStore(settings);

--- a/src/main.ts
+++ b/src/main.ts
@@ -137,6 +137,9 @@ async function main(): Promise<void> {
   );
 
   const settingsMap = configToSettings(config);
+  for (const [k, v] of Object.entries(process.env)) {
+    if (k.startsWith('CTI_FEISHU_BOTS_') && v) settingsMap.set(k, v);
+  }
   const feishuBotConfigs = parseFeishuBotConfigs(settingsMap);
   const globalStore = new JsonFileStore(settingsMap);
   const botStores = new Map<string, BridgeStore>();

--- a/src/main.ts
+++ b/src/main.ts
@@ -14,8 +14,8 @@ import * as bridgeManager from 'claude-to-im/src/lib/bridge/bridge-manager.js';
 import 'claude-to-im/src/lib/bridge/adapters/index.js';
 import './adapters/weixin-adapter.js';
 
-import type { LLMProvider } from 'claude-to-im/src/lib/bridge/host.js';
-import { loadConfig, configToSettings, CTI_HOME } from './config.js';
+import type { BridgeStore, LLMProvider } from 'claude-to-im/src/lib/bridge/host.js';
+import { loadConfig, configToSettings, parseFeishuBotConfigs, CTI_HOME } from './config.js';
 import type { Config } from './config.js';
 import { JsonFileStore } from './store.js';
 import { SDKLLMProvider, resolveClaudeCliPath, preflightCheck } from './llm-provider.js';
@@ -136,8 +136,15 @@ async function main(): Promise<void> {
     (config.minimaxApiKey ? ', LLM classifier: ready' : ', LLM classifier: no API key'),
   );
 
-  const settings = configToSettings(config);
-  const store = new JsonFileStore(settings);
+  const settingsMap = configToSettings(config);
+  const feishuBotConfigs = parseFeishuBotConfigs(settingsMap);
+  const globalStore = new JsonFileStore(settingsMap);
+  const botStores = new Map<string, BridgeStore>();
+  for (const botConfig of feishuBotConfigs) {
+    const dataDir = path.join(CTI_HOME, 'data', botConfig.name);
+    fs.mkdirSync(dataDir, { recursive: true });
+    botStores.set(botConfig.name, new JsonFileStore(settingsMap, dataDir));
+  }
   const pendingPerms = new PendingPermissions();
   const llm = await resolveProvider(config, pendingPerms);
   console.log(`[claude-to-im] Runtime: ${config.runtime}`);
@@ -148,7 +155,9 @@ async function main(): Promise<void> {
   };
 
   initBridgeContext({
-    store,
+    store: globalStore,
+    feishuBotConfigs,
+    botStores,
     llm,
     permissions: gateway,
     lifecycle: {

--- a/src/permission-gateway.ts
+++ b/src/permission-gateway.ts
@@ -1,0 +1,52 @@
+export interface PermissionResult {
+  behavior: 'allow' | 'deny';
+  message?: string;
+}
+
+export interface PermissionResolution {
+  behavior: 'allow' | 'deny';
+  message?: string;
+}
+
+export class PendingPermissions {
+  private pending = new Map<string, {
+    resolve: (r: PermissionResult) => void;
+    timer: NodeJS.Timeout;
+  }>();
+  private timeoutMs = 5 * 60 * 1000; // 5 minutes
+
+  waitFor(toolUseID: string): Promise<PermissionResult> {
+    return new Promise((resolve) => {
+      const timer = setTimeout(() => {
+        this.pending.delete(toolUseID);
+        resolve({ behavior: 'deny', message: 'Permission request timed out' });
+      }, this.timeoutMs);
+      this.pending.set(toolUseID, { resolve, timer });
+    });
+  }
+
+  resolve(permissionRequestId: string, resolution: PermissionResolution): boolean {
+    const entry = this.pending.get(permissionRequestId);
+    if (!entry) return false;
+    clearTimeout(entry.timer);
+    if (resolution.behavior === 'allow') {
+      entry.resolve({ behavior: 'allow' });
+    } else {
+      entry.resolve({ behavior: 'deny', message: resolution.message || 'Denied by user' });
+    }
+    this.pending.delete(permissionRequestId);
+    return true;
+  }
+
+  denyAll(): void {
+    for (const [, entry] of this.pending) {
+      clearTimeout(entry.timer);
+      entry.resolve({ behavior: 'deny', message: 'Bridge shutting down' });
+    }
+    this.pending.clear();
+  }
+
+  get size(): number {
+    return this.pending.size;
+  }
+}

--- a/src/qrcode.d.ts
+++ b/src/qrcode.d.ts
@@ -1,0 +1,14 @@
+declare module 'qrcode' {
+  interface ToStringOptions {
+    type?: 'svg' | 'utf8' | 'terminal';
+    errorCorrectionLevel?: 'L' | 'M' | 'Q' | 'H';
+    margin?: number;
+    width?: number;
+  }
+
+  const QRCode: {
+    toString(text: string, options?: ToStringOptions): Promise<string>;
+  };
+
+  export default QRCode;
+}

--- a/src/sse-utils.ts
+++ b/src/sse-utils.ts
@@ -1,0 +1,11 @@
+/**
+ * SSE Utilities — helpers for formatting Server-Sent Event strings.
+ *
+ * Used by LLMProvider implementations to produce the SSE stream format
+ * consumed by the bridge conversation engine.
+ */
+
+export function sseEvent(type: string, data: unknown): string {
+  const payload = typeof data === 'string' ? data : JSON.stringify(data);
+  return `data: ${JSON.stringify({ type, data: payload })}\n`;
+}

--- a/src/store.ts
+++ b/src/store.ts
@@ -1,0 +1,473 @@
+/**
+ * JSON file-backed BridgeStore implementation.
+ *
+ * Uses in-memory Maps as cache with write-through persistence
+ * to JSON files in ~/.claude-to-im/data/.
+ */
+
+import fs from 'node:fs';
+import path from 'node:path';
+import crypto from 'node:crypto';
+import type {
+  BridgeStore,
+  BridgeSession,
+  BridgeMessage,
+  BridgeApiProvider,
+  AuditLogInput,
+  PermissionLinkInput,
+  PermissionLinkRecord,
+  OutboundRefInput,
+  UpsertChannelBindingInput,
+} from 'claude-to-im/src/lib/bridge/host.js';
+import type { ChannelBinding, ChannelType } from 'claude-to-im/src/lib/bridge/types.js';
+import { CTI_HOME } from './config.js';
+
+const DATA_DIR = path.join(CTI_HOME, 'data');
+const MESSAGES_DIR = path.join(DATA_DIR, 'messages');
+
+// ── Helpers ──
+
+function ensureDir(dir: string): void {
+  fs.mkdirSync(dir, { recursive: true });
+}
+
+function atomicWrite(filePath: string, data: string): void {
+  const tmp = filePath + '.tmp';
+  fs.writeFileSync(tmp, data, 'utf-8');
+  fs.renameSync(tmp, filePath);
+}
+
+function readJson<T>(filePath: string, fallback: T): T {
+  try {
+    const raw = fs.readFileSync(filePath, 'utf-8');
+    return JSON.parse(raw) as T;
+  } catch {
+    return fallback;
+  }
+}
+
+function writeJson(filePath: string, data: unknown): void {
+  atomicWrite(filePath, JSON.stringify(data, null, 2));
+}
+
+function uuid(): string {
+  return crypto.randomUUID();
+}
+
+function now(): string {
+  return new Date().toISOString();
+}
+
+// ── Lock entry ──
+
+interface LockEntry {
+  lockId: string;
+  owner: string;
+  expiresAt: number;
+}
+
+// ── Store ──
+
+export class JsonFileStore implements BridgeStore {
+  private settings: Map<string, string>;
+  private sessions = new Map<string, BridgeSession>();
+  private bindings = new Map<string, ChannelBinding>();
+  private messages = new Map<string, BridgeMessage[]>();
+  private permissionLinks = new Map<string, PermissionLinkRecord>();
+  private offsets = new Map<string, string>();
+  private dedupKeys = new Map<string, number>();
+  private locks = new Map<string, LockEntry>();
+  private auditLog: Array<AuditLogInput & { id: string; createdAt: string }> = [];
+
+  constructor(settingsMap: Map<string, string>) {
+    this.settings = settingsMap;
+    ensureDir(DATA_DIR);
+    ensureDir(MESSAGES_DIR);
+    this.loadAll();
+  }
+
+  // ── Persistence ──
+
+  private loadAll(): void {
+    // Sessions
+    const sessions = readJson<Record<string, BridgeSession>>(
+      path.join(DATA_DIR, 'sessions.json'),
+      {},
+    );
+    for (const [id, s] of Object.entries(sessions)) {
+      this.sessions.set(id, s);
+    }
+
+    // Bindings
+    const bindings = readJson<Record<string, ChannelBinding>>(
+      path.join(DATA_DIR, 'bindings.json'),
+      {},
+    );
+    for (const [key, b] of Object.entries(bindings)) {
+      this.bindings.set(key, b);
+    }
+
+    // Permission links
+    const perms = readJson<Record<string, PermissionLinkRecord>>(
+      path.join(DATA_DIR, 'permissions.json'),
+      {},
+    );
+    for (const [id, p] of Object.entries(perms)) {
+      this.permissionLinks.set(id, p);
+    }
+
+    // Offsets
+    const offsets = readJson<Record<string, string>>(
+      path.join(DATA_DIR, 'offsets.json'),
+      {},
+    );
+    for (const [k, v] of Object.entries(offsets)) {
+      this.offsets.set(k, v);
+    }
+
+    // Dedup
+    const dedup = readJson<Record<string, number>>(
+      path.join(DATA_DIR, 'dedup.json'),
+      {},
+    );
+    for (const [k, v] of Object.entries(dedup)) {
+      this.dedupKeys.set(k, v);
+    }
+
+    // Audit
+    this.auditLog = readJson(path.join(DATA_DIR, 'audit.json'), []);
+  }
+
+  private persistSessions(): void {
+    writeJson(
+      path.join(DATA_DIR, 'sessions.json'),
+      Object.fromEntries(this.sessions),
+    );
+  }
+
+  private persistBindings(): void {
+    writeJson(
+      path.join(DATA_DIR, 'bindings.json'),
+      Object.fromEntries(this.bindings),
+    );
+  }
+
+  private persistPermissions(): void {
+    writeJson(
+      path.join(DATA_DIR, 'permissions.json'),
+      Object.fromEntries(this.permissionLinks),
+    );
+  }
+
+  private persistOffsets(): void {
+    writeJson(
+      path.join(DATA_DIR, 'offsets.json'),
+      Object.fromEntries(this.offsets),
+    );
+  }
+
+  private persistDedup(): void {
+    writeJson(
+      path.join(DATA_DIR, 'dedup.json'),
+      Object.fromEntries(this.dedupKeys),
+    );
+  }
+
+  private persistAudit(): void {
+    writeJson(path.join(DATA_DIR, 'audit.json'), this.auditLog);
+  }
+
+  private persistMessages(sessionId: string): void {
+    const msgs = this.messages.get(sessionId) || [];
+    writeJson(path.join(MESSAGES_DIR, `${sessionId}.json`), msgs);
+  }
+
+  private loadMessages(sessionId: string): BridgeMessage[] {
+    if (this.messages.has(sessionId)) {
+      return this.messages.get(sessionId)!;
+    }
+    const msgs = readJson<BridgeMessage[]>(
+      path.join(MESSAGES_DIR, `${sessionId}.json`),
+      [],
+    );
+    this.messages.set(sessionId, msgs);
+    return msgs;
+  }
+
+  // ── Settings ──
+
+  getSetting(key: string): string | null {
+    return this.settings.get(key) ?? null;
+  }
+
+  // ── Channel Bindings ──
+
+  getChannelBinding(channelType: string, chatId: string): ChannelBinding | null {
+    return this.bindings.get(`${channelType}:${chatId}`) ?? null;
+  }
+
+  upsertChannelBinding(data: UpsertChannelBindingInput): ChannelBinding {
+    const key = `${data.channelType}:${data.chatId}`;
+    const existing = this.bindings.get(key);
+    if (existing) {
+      const updated: ChannelBinding = {
+        ...existing,
+        codepilotSessionId: data.codepilotSessionId,
+        workingDirectory: data.workingDirectory,
+        model: data.model,
+        updatedAt: now(),
+      };
+      this.bindings.set(key, updated);
+      this.persistBindings();
+      return updated;
+    }
+    const binding: ChannelBinding = {
+      id: uuid(),
+      channelType: data.channelType,
+      chatId: data.chatId,
+      codepilotSessionId: data.codepilotSessionId,
+      sdkSessionId: '',
+      workingDirectory: data.workingDirectory,
+      model: data.model,
+      mode: (this.settings.get('bridge_default_mode') as 'code' | 'plan' | 'ask') || 'code',
+      active: true,
+      createdAt: now(),
+      updatedAt: now(),
+    };
+    this.bindings.set(key, binding);
+    this.persistBindings();
+    return binding;
+  }
+
+  updateChannelBinding(id: string, updates: Partial<ChannelBinding>): void {
+    for (const [key, b] of this.bindings) {
+      if (b.id === id) {
+        this.bindings.set(key, { ...b, ...updates, updatedAt: now() });
+        this.persistBindings();
+        break;
+      }
+    }
+  }
+
+  listChannelBindings(channelType?: ChannelType): ChannelBinding[] {
+    const all = Array.from(this.bindings.values());
+    if (!channelType) return all;
+    return all.filter((b) => b.channelType === channelType);
+  }
+
+  // ── Sessions ──
+
+  getSession(id: string): BridgeSession | null {
+    return this.sessions.get(id) ?? null;
+  }
+
+  createSession(
+    _name: string,
+    model: string,
+    systemPrompt?: string,
+    cwd?: string,
+    _mode?: string,
+  ): BridgeSession {
+    const session: BridgeSession = {
+      id: uuid(),
+      working_directory: cwd || this.settings.get('bridge_default_work_dir') || process.cwd(),
+      model,
+      system_prompt: systemPrompt,
+    };
+    this.sessions.set(session.id, session);
+    this.persistSessions();
+    return session;
+  }
+
+  updateSessionProviderId(sessionId: string, providerId: string): void {
+    const s = this.sessions.get(sessionId);
+    if (s) {
+      s.provider_id = providerId;
+      this.persistSessions();
+    }
+  }
+
+  // ── Messages ──
+
+  addMessage(sessionId: string, role: string, content: string, _usage?: string | null): void {
+    const msgs = this.loadMessages(sessionId);
+    msgs.push({ role, content });
+    this.persistMessages(sessionId);
+  }
+
+  getMessages(sessionId: string, opts?: { limit?: number }): { messages: BridgeMessage[] } {
+    const msgs = this.loadMessages(sessionId);
+    if (opts?.limit && opts.limit > 0) {
+      return { messages: msgs.slice(-opts.limit) };
+    }
+    return { messages: [...msgs] };
+  }
+
+  // ── Session Locking ──
+
+  acquireSessionLock(sessionId: string, lockId: string, owner: string, ttlSecs: number): boolean {
+    const existing = this.locks.get(sessionId);
+    if (existing && existing.expiresAt > Date.now()) {
+      // Lock held by someone else
+      if (existing.lockId !== lockId) return false;
+    }
+    this.locks.set(sessionId, {
+      lockId,
+      owner,
+      expiresAt: Date.now() + ttlSecs * 1000,
+    });
+    return true;
+  }
+
+  renewSessionLock(sessionId: string, lockId: string, ttlSecs: number): void {
+    const lock = this.locks.get(sessionId);
+    if (lock && lock.lockId === lockId) {
+      lock.expiresAt = Date.now() + ttlSecs * 1000;
+    }
+  }
+
+  releaseSessionLock(sessionId: string, lockId: string): void {
+    const lock = this.locks.get(sessionId);
+    if (lock && lock.lockId === lockId) {
+      this.locks.delete(sessionId);
+    }
+  }
+
+  setSessionRuntimeStatus(_sessionId: string, _status: string): void {
+    // no-op for file-based store
+  }
+
+  // ── SDK Session ──
+
+  updateSdkSessionId(sessionId: string, sdkSessionId: string): void {
+    const s = this.sessions.get(sessionId);
+    if (s) {
+      // Store sdkSessionId on the session object
+      (s as unknown as Record<string, unknown>)['sdk_session_id'] = sdkSessionId;
+      this.persistSessions();
+    }
+    // Also update any bindings that reference this session
+    for (const [key, b] of this.bindings) {
+      if (b.codepilotSessionId === sessionId) {
+        this.bindings.set(key, { ...b, sdkSessionId, updatedAt: now() });
+      }
+    }
+    this.persistBindings();
+  }
+
+  updateSessionModel(sessionId: string, model: string): void {
+    const s = this.sessions.get(sessionId);
+    if (s) {
+      s.model = model;
+      this.persistSessions();
+    }
+  }
+
+  syncSdkTasks(_sessionId: string, _todos: unknown): void {
+    // no-op
+  }
+
+  // ── Provider ──
+
+  getProvider(_id: string): BridgeApiProvider | undefined {
+    return undefined;
+  }
+
+  getDefaultProviderId(): string | null {
+    return null;
+  }
+
+  // ── Audit & Dedup ──
+
+  insertAuditLog(entry: AuditLogInput): void {
+    this.auditLog.push({
+      ...entry,
+      id: uuid(),
+      createdAt: now(),
+    });
+    // Ring buffer: keep last 1000
+    if (this.auditLog.length > 1000) {
+      this.auditLog = this.auditLog.slice(-1000);
+    }
+    this.persistAudit();
+  }
+
+  checkDedup(key: string): boolean {
+    const ts = this.dedupKeys.get(key);
+    if (ts === undefined) return false;
+    // 5 minute window
+    if (Date.now() - ts > 5 * 60 * 1000) {
+      this.dedupKeys.delete(key);
+      return false;
+    }
+    return true;
+  }
+
+  insertDedup(key: string): void {
+    this.dedupKeys.set(key, Date.now());
+    this.persistDedup();
+  }
+
+  cleanupExpiredDedup(): void {
+    const cutoff = Date.now() - 5 * 60 * 1000;
+    let changed = false;
+    for (const [key, ts] of this.dedupKeys) {
+      if (ts < cutoff) {
+        this.dedupKeys.delete(key);
+        changed = true;
+      }
+    }
+    if (changed) this.persistDedup();
+  }
+
+  insertOutboundRef(_ref: OutboundRefInput): void {
+    // no-op for file-based store
+  }
+
+  // ── Permission Links ──
+
+  insertPermissionLink(link: PermissionLinkInput): void {
+    const record: PermissionLinkRecord = {
+      permissionRequestId: link.permissionRequestId,
+      chatId: link.chatId,
+      messageId: link.messageId,
+      resolved: false,
+      suggestions: link.suggestions,
+    };
+    this.permissionLinks.set(link.permissionRequestId, record);
+    this.persistPermissions();
+  }
+
+  getPermissionLink(permissionRequestId: string): PermissionLinkRecord | null {
+    return this.permissionLinks.get(permissionRequestId) ?? null;
+  }
+
+  markPermissionLinkResolved(permissionRequestId: string): boolean {
+    const link = this.permissionLinks.get(permissionRequestId);
+    if (!link || link.resolved) return false;
+    link.resolved = true;
+    this.persistPermissions();
+    return true;
+  }
+
+  listPendingPermissionLinksByChat(chatId: string): PermissionLinkRecord[] {
+    const result: PermissionLinkRecord[] = [];
+    for (const link of this.permissionLinks.values()) {
+      if (link.chatId === chatId && !link.resolved) {
+        result.push(link);
+      }
+    }
+    return result;
+  }
+
+  // ── Channel Offsets ──
+
+  getChannelOffset(key: string): string {
+    return this.offsets.get(key) ?? '0';
+  }
+
+  setChannelOffset(key: string, offset: string): void {
+    this.offsets.set(key, offset);
+    this.persistOffsets();
+  }
+}

--- a/src/store.ts
+++ b/src/store.ts
@@ -22,9 +22,6 @@ import type {
 import type { ChannelBinding, ChannelType } from 'claude-to-im/src/lib/bridge/types.js';
 import { CTI_HOME } from './config.js';
 
-const DATA_DIR = path.join(CTI_HOME, 'data');
-const MESSAGES_DIR = path.join(DATA_DIR, 'messages');
-
 // ── Helpers ──
 
 function ensureDir(dir: string): void {
@@ -69,6 +66,8 @@ interface LockEntry {
 // ── Store ──
 
 export class JsonFileStore implements BridgeStore {
+  private dataDir: string;
+  private messagesDir: string;
   private settings: Map<string, string>;
   private sessions = new Map<string, BridgeSession>();
   private bindings = new Map<string, ChannelBinding>();
@@ -79,10 +78,13 @@ export class JsonFileStore implements BridgeStore {
   private locks = new Map<string, LockEntry>();
   private auditLog: Array<AuditLogInput & { id: string; createdAt: string }> = [];
 
-  constructor(settingsMap: Map<string, string>) {
+  constructor(settingsMap: Map<string, string>, dataDir?: string) {
     this.settings = settingsMap;
-    ensureDir(DATA_DIR);
-    ensureDir(MESSAGES_DIR);
+    const ctiHome = settingsMap.get('CTI_HOME') || CTI_HOME;
+    this.dataDir = dataDir || path.join(ctiHome, 'data');
+    this.messagesDir = path.join(this.dataDir, 'messages');
+    ensureDir(this.dataDir);
+    ensureDir(this.messagesDir);
     this.loadAll();
   }
 
@@ -91,7 +93,7 @@ export class JsonFileStore implements BridgeStore {
   private loadAll(): void {
     // Sessions
     const sessions = readJson<Record<string, BridgeSession>>(
-      path.join(DATA_DIR, 'sessions.json'),
+      path.join(this.dataDir, 'sessions.json'),
       {},
     );
     for (const [id, s] of Object.entries(sessions)) {
@@ -100,7 +102,7 @@ export class JsonFileStore implements BridgeStore {
 
     // Bindings
     const bindings = readJson<Record<string, ChannelBinding>>(
-      path.join(DATA_DIR, 'bindings.json'),
+      path.join(this.dataDir, 'bindings.json'),
       {},
     );
     for (const [key, b] of Object.entries(bindings)) {
@@ -109,7 +111,7 @@ export class JsonFileStore implements BridgeStore {
 
     // Permission links
     const perms = readJson<Record<string, PermissionLinkRecord>>(
-      path.join(DATA_DIR, 'permissions.json'),
+      path.join(this.dataDir, 'permissions.json'),
       {},
     );
     for (const [id, p] of Object.entries(perms)) {
@@ -118,7 +120,7 @@ export class JsonFileStore implements BridgeStore {
 
     // Offsets
     const offsets = readJson<Record<string, string>>(
-      path.join(DATA_DIR, 'offsets.json'),
+      path.join(this.dataDir, 'offsets.json'),
       {},
     );
     for (const [k, v] of Object.entries(offsets)) {
@@ -127,7 +129,7 @@ export class JsonFileStore implements BridgeStore {
 
     // Dedup
     const dedup = readJson<Record<string, number>>(
-      path.join(DATA_DIR, 'dedup.json'),
+      path.join(this.dataDir, 'dedup.json'),
       {},
     );
     for (const [k, v] of Object.entries(dedup)) {
@@ -135,51 +137,51 @@ export class JsonFileStore implements BridgeStore {
     }
 
     // Audit
-    this.auditLog = readJson(path.join(DATA_DIR, 'audit.json'), []);
+    this.auditLog = readJson(path.join(this.dataDir, 'audit.json'), []);
   }
 
   private persistSessions(): void {
     writeJson(
-      path.join(DATA_DIR, 'sessions.json'),
+      path.join(this.dataDir, 'sessions.json'),
       Object.fromEntries(this.sessions),
     );
   }
 
   private persistBindings(): void {
     writeJson(
-      path.join(DATA_DIR, 'bindings.json'),
+      path.join(this.dataDir, 'bindings.json'),
       Object.fromEntries(this.bindings),
     );
   }
 
   private persistPermissions(): void {
     writeJson(
-      path.join(DATA_DIR, 'permissions.json'),
+      path.join(this.dataDir, 'permissions.json'),
       Object.fromEntries(this.permissionLinks),
     );
   }
 
   private persistOffsets(): void {
     writeJson(
-      path.join(DATA_DIR, 'offsets.json'),
+      path.join(this.dataDir, 'offsets.json'),
       Object.fromEntries(this.offsets),
     );
   }
 
   private persistDedup(): void {
     writeJson(
-      path.join(DATA_DIR, 'dedup.json'),
+      path.join(this.dataDir, 'dedup.json'),
       Object.fromEntries(this.dedupKeys),
     );
   }
 
   private persistAudit(): void {
-    writeJson(path.join(DATA_DIR, 'audit.json'), this.auditLog);
+    writeJson(path.join(this.dataDir, 'audit.json'), this.auditLog);
   }
 
   private persistMessages(sessionId: string): void {
     const msgs = this.messages.get(sessionId) || [];
-    writeJson(path.join(MESSAGES_DIR, `${sessionId}.json`), msgs);
+    writeJson(path.join(this.messagesDir, `${sessionId}.json`), msgs);
   }
 
   private loadMessages(sessionId: string): BridgeMessage[] {
@@ -187,7 +189,7 @@ export class JsonFileStore implements BridgeStore {
       return this.messages.get(sessionId)!;
     }
     const msgs = readJson<BridgeMessage[]>(
-      path.join(MESSAGES_DIR, `${sessionId}.json`),
+      path.join(this.messagesDir, `${sessionId}.json`),
       [],
     );
     this.messages.set(sessionId, msgs);
@@ -202,16 +204,20 @@ export class JsonFileStore implements BridgeStore {
 
   // ── Channel Bindings ──
 
-  getChannelBinding(channelType: string, chatId: string): ChannelBinding | null {
-    return this.bindings.get(`${channelType}:${chatId}`) ?? null;
+  getChannelBinding(channelType: ChannelType, chatId: string, botName?: string): ChannelBinding | null {
+    const key = botName ? `${channelType}:${botName}:${chatId}` : `${channelType}:${chatId}`;
+    return this.bindings.get(key) ?? null;
   }
 
   upsertChannelBinding(data: UpsertChannelBindingInput): ChannelBinding {
-    const key = `${data.channelType}:${data.chatId}`;
+    const key = data.botName
+      ? `${data.channelType}:${data.botName}:${data.chatId}`
+      : `${data.channelType}:${data.chatId}`;
     const existing = this.bindings.get(key);
     if (existing) {
       const updated: ChannelBinding = {
         ...existing,
+        botName: data.botName,
         codepilotSessionId: data.codepilotSessionId,
         workingDirectory: data.workingDirectory,
         model: data.model,
@@ -224,6 +230,7 @@ export class JsonFileStore implements BridgeStore {
     const binding: ChannelBinding = {
       id: uuid(),
       channelType: data.channelType,
+      botName: data.botName,
       chatId: data.chatId,
       codepilotSessionId: data.codepilotSessionId,
       sdkSessionId: '',

--- a/src/weixin-login.ts
+++ b/src/weixin-login.ts
@@ -1,0 +1,274 @@
+import fs from 'node:fs';
+import path from 'node:path';
+import { spawn } from 'node:child_process';
+import QRCode from 'qrcode';
+import { CTI_HOME, loadConfig } from './config.js';
+import { startLoginQr, pollLoginQrStatus } from './adapters/weixin/weixin-api.js';
+import { DEFAULT_BASE_URL, DEFAULT_CDN_BASE_URL } from './adapters/weixin/weixin-types.js';
+import { listWeixinAccounts, upsertWeixinAccount } from './weixin-store.js';
+
+type LoginStatus = 'waiting' | 'scanned' | 'confirmed' | 'failed';
+
+interface LoginSession {
+  qrcode: string;
+  qrImageUrl: string;
+  status: LoginStatus;
+  startedAt: number;
+  refreshCount: number;
+}
+
+const MAX_REFRESHES = 3;
+const QR_TTL_MS = 5 * 60_000;
+const POLL_INTERVAL_MS = 3_000;
+const RUNTIME_DIR = path.join(CTI_HOME, 'runtime');
+const HTML_PATH = path.join(RUNTIME_DIR, 'weixin-login.html');
+
+function ensureRuntimeDir(): void {
+  fs.mkdirSync(RUNTIME_DIR, { recursive: true });
+}
+
+function escapeHtml(text: string): string {
+  return text
+    .replaceAll('&', '&amp;')
+    .replaceAll('<', '&lt;')
+    .replaceAll('>', '&gt;')
+    .replaceAll('"', '&quot;');
+}
+
+export function buildQrHtml(session: LoginSession, qrSvg: string): string {
+  return `<!doctype html>
+<html lang="zh-CN">
+  <head>
+    <meta charset="utf-8" />
+    <meta name="viewport" content="width=device-width, initial-scale=1" />
+    <title>Claude-to-IM WeChat Login</title>
+    <style>
+      :root { color-scheme: light; }
+      body {
+        margin: 0;
+        font-family: -apple-system, BlinkMacSystemFont, "PingFang SC", "Helvetica Neue", sans-serif;
+        background: linear-gradient(180deg, #f6fbf8 0%, #eef5ff 100%);
+        color: #14213d;
+      }
+      .wrap {
+        max-width: 760px;
+        margin: 0 auto;
+        min-height: 100vh;
+        display: flex;
+        align-items: center;
+        justify-content: center;
+        padding: 32px 20px;
+      }
+      .card {
+        width: 100%;
+        background: rgba(255,255,255,0.92);
+        border: 1px solid rgba(20,33,61,0.08);
+        border-radius: 24px;
+        box-shadow: 0 20px 50px rgba(36, 82, 167, 0.12);
+        padding: 28px;
+      }
+      h1 { margin: 0 0 12px; font-size: 28px; }
+      p { line-height: 1.6; margin: 8px 0; }
+      .qr {
+        display: flex;
+        justify-content: center;
+        margin: 28px 0;
+      }
+      #qrcode {
+        display: flex;
+        justify-content: center;
+      }
+      #qrcode svg {
+        width: 300px;
+        height: 300px;
+        border-radius: 18px;
+        background: white;
+        border: 1px solid rgba(20,33,61,0.08);
+        padding: 16px;
+      }
+      ol {
+        margin: 18px 0 0;
+        padding-left: 22px;
+      }
+      code {
+        display: inline-block;
+        padding: 2px 8px;
+        border-radius: 999px;
+        background: #eef3ff;
+        color: #2452a7;
+      }
+      .muted { color: #5b6b86; font-size: 14px; }
+    </style>
+  </head>
+  <body>
+    <div class="wrap">
+      <div class="card">
+        <h1>微信扫码登录 Claude-to-IM</h1>
+        <p>请用手机微信扫描下面的二维码，并在手机上确认登录授权。</p>
+        <p class="muted">如果二维码过期，CLI 会自动刷新这个页面内容；如果浏览器没有更新，请手动刷新一次。</p>
+        <div class="qr">
+          <div id="qrcode">${qrSvg}</div>
+        </div>
+        <ol>
+          <li>打开手机微信扫一扫</li>
+          <li>扫描页面二维码</li>
+          <li>在手机上确认授权</li>
+          <li>回到 CLI，等待显示登录成功</li>
+        </ol>
+        <p class="muted">HTML 文件：<code>${escapeHtml(HTML_PATH)}</code></p>
+      </div>
+    </div>
+  </body>
+</html>
+`;
+}
+
+async function writeQrHtml(session: LoginSession): Promise<void> {
+  ensureRuntimeDir();
+  const qrSvg = await QRCode.toString(session.qrImageUrl, {
+    type: 'svg',
+    errorCorrectionLevel: 'M',
+    margin: 0,
+    width: 300,
+  });
+  fs.writeFileSync(HTML_PATH, buildQrHtml(session, qrSvg), 'utf-8');
+}
+
+function openQrHtml(): boolean {
+  try {
+    if (process.platform === 'darwin') {
+      const child = spawn('open', [HTML_PATH], { detached: true, stdio: 'ignore' });
+      child.unref();
+      return true;
+    }
+    if (process.platform === 'win32') {
+      const child = spawn('cmd', ['/c', 'start', '', HTML_PATH], { detached: true, stdio: 'ignore' });
+      child.unref();
+      return true;
+    }
+    const child = spawn('xdg-open', [HTML_PATH], { detached: true, stdio: 'ignore' });
+    child.unref();
+    return true;
+  } catch {
+    return false;
+  }
+}
+
+function normalizeAccountId(rawAccountId: string): string {
+  return rawAccountId.replace(/[@.]/g, '-');
+}
+
+function sleep(ms: number): Promise<void> {
+  return new Promise((resolve) => setTimeout(resolve, ms));
+}
+
+async function createSession(refreshCount: number, baseUrl?: string): Promise<LoginSession> {
+  const response = await startLoginQr(baseUrl);
+  if (!response.qrcode || !response.qrcode_img_content) {
+    throw new Error('Failed to get QR code from WeChat server');
+  }
+  return {
+    qrcode: response.qrcode,
+    qrImageUrl: response.qrcode_img_content,
+    status: 'waiting',
+    startedAt: Date.now(),
+    refreshCount,
+  };
+}
+
+async function refreshSession(previous: LoginSession, baseUrl?: string): Promise<LoginSession> {
+  if (previous.refreshCount >= MAX_REFRESHES) {
+    throw new Error('QR code expired too many times. Please run the login helper again.');
+  }
+  const next = await createSession(previous.refreshCount + 1, baseUrl);
+  await writeQrHtml(next);
+  openQrHtml();
+  console.log(`[weixin-login] QR code refreshed (${next.refreshCount}/${MAX_REFRESHES})`);
+  return next;
+}
+
+export async function runWeixinLogin(): Promise<{ accountId: string; htmlPath: string }> {
+  ensureRuntimeDir();
+  const config = loadConfig();
+  let session = await createSession(0, config.weixinBaseUrl);
+  await writeQrHtml(session);
+  const opened = openQrHtml();
+
+  console.log('[weixin-login] WeChat QR login started');
+  console.log(`[weixin-login] QR page: ${HTML_PATH}`);
+  if (!opened) {
+    console.log('[weixin-login] Auto-open failed. Open the HTML file above manually in your browser.');
+  }
+
+  let lastStatus: LoginStatus = session.status;
+
+  while (true) {
+    if (Date.now() - session.startedAt > QR_TTL_MS) {
+      session = await refreshSession(session, config.weixinBaseUrl);
+      lastStatus = session.status;
+    }
+
+    const response = await pollLoginQrStatus(session.qrcode, config.weixinBaseUrl);
+    switch (response.status) {
+      case 'wait':
+        session.status = 'waiting';
+        break;
+      case 'scaned':
+        session.status = 'scanned';
+        break;
+      case 'confirmed': {
+        if (!response.bot_token || !response.ilink_bot_id) {
+          throw new Error('QR login confirmed, but WeChat did not return bot credentials.');
+        }
+        session.status = 'confirmed';
+        const accountId = normalizeAccountId(response.ilink_bot_id);
+        const previousAccount = listWeixinAccounts()[0];
+        upsertWeixinAccount({
+          accountId,
+          userId: response.ilink_user_id || '',
+          baseUrl: config.weixinBaseUrl || response.baseurl || DEFAULT_BASE_URL,
+          cdnBaseUrl: config.weixinCdnBaseUrl || DEFAULT_CDN_BASE_URL,
+          token: response.bot_token,
+          name: accountId,
+          enabled: true,
+        });
+        console.log(`[weixin-login] Login successful. Saved linked account ${accountId}`);
+        if (previousAccount && previousAccount.accountId !== accountId) {
+          console.log(`[weixin-login] Replaced previous local account ${previousAccount.accountId}`);
+        }
+        console.log('[weixin-login] You can now enable the `weixin` channel and start the bridge.');
+        return { accountId, htmlPath: HTML_PATH };
+      }
+      case 'expired':
+        session = await refreshSession(session, config.weixinBaseUrl);
+        lastStatus = session.status;
+        continue;
+      default:
+        session.status = 'waiting';
+        break;
+    }
+
+    if (session.status !== lastStatus) {
+      if (session.status === 'scanned') {
+        console.log('[weixin-login] QR scanned. Please confirm the login in WeChat.');
+      } else if (session.status === 'waiting') {
+        console.log('[weixin-login] Waiting for QR scan...');
+      }
+      lastStatus = session.status;
+    }
+
+    await sleep(POLL_INTERVAL_MS);
+  }
+}
+
+const isMainModule = (() => {
+  const entry = process.argv[1];
+  return !!entry && path.resolve(entry) === path.resolve(new URL(import.meta.url).pathname);
+})();
+
+if (isMainModule) {
+  runWeixinLogin().catch((err) => {
+    console.error('[weixin-login] Failed:', err instanceof Error ? err.message : String(err));
+    process.exitCode = 1;
+  });
+}

--- a/src/weixin-store.ts
+++ b/src/weixin-store.ts
@@ -1,0 +1,235 @@
+import fs from 'node:fs';
+import path from 'node:path';
+import { CTI_HOME } from './config.js';
+
+export interface WeixinAccountRecord {
+  accountId: string;
+  userId: string;
+  baseUrl: string;
+  cdnBaseUrl: string;
+  token: string;
+  name: string;
+  enabled: boolean;
+  lastLoginAt: string | null;
+  createdAt: string;
+  updatedAt: string;
+}
+
+const DATA_DIR = path.join(CTI_HOME, 'data');
+// Keep the historical plural filename for compatibility, even though the
+// current Weixin bridge intentionally runs in single-account mode.
+const ACCOUNTS_PATH = path.join(DATA_DIR, 'weixin-accounts.json');
+const CONTEXT_TOKENS_PATH = path.join(DATA_DIR, 'weixin-context-tokens.json');
+const DEFAULT_BASE_URL = 'https://ilinkai.weixin.qq.com';
+const DEFAULT_CDN_BASE_URL = 'https://novac2c.cdn.weixin.qq.com/c2c';
+
+function ensureDir(dir: string): void {
+  fs.mkdirSync(dir, { recursive: true });
+}
+
+function atomicWrite(filePath: string, data: string): void {
+  const tmpPath = `${filePath}.tmp`;
+  fs.writeFileSync(tmpPath, data, 'utf-8');
+  fs.renameSync(tmpPath, filePath);
+}
+
+function readJson<T>(filePath: string, fallback: T): T {
+  try {
+    const raw = fs.readFileSync(filePath, 'utf-8');
+    return JSON.parse(raw) as T;
+  } catch {
+    return fallback;
+  }
+}
+
+function now(): string {
+  return new Date().toISOString();
+}
+
+function getAccountRecency(account: WeixinAccountRecord): string {
+  return account.lastLoginAt ?? account.updatedAt ?? account.createdAt;
+}
+
+function normalizeAccounts(accounts: WeixinAccountRecord[]): {
+  accounts: WeixinAccountRecord[];
+  removedAccountIds: string[];
+} {
+  // Single-account mode: the newest linked account wins and older records
+  // are treated as replaceable history.
+  if (accounts.length <= 1) {
+    return { accounts, removedAccountIds: [] };
+  }
+
+  const sorted = [...accounts].sort((a, b) => {
+    const recencyDiff = getAccountRecency(b).localeCompare(getAccountRecency(a));
+    if (recencyDiff !== 0) return recencyDiff;
+
+    const updatedDiff = b.updatedAt.localeCompare(a.updatedAt);
+    if (updatedDiff !== 0) return updatedDiff;
+
+    const createdDiff = b.createdAt.localeCompare(a.createdAt);
+    if (createdDiff !== 0) return createdDiff;
+
+    return 0;
+  });
+
+  const kept = sorted[0];
+  const removedAccountIds = [
+    ...new Set(
+      sorted
+        .slice(1)
+        .map((account) => account.accountId)
+        .filter((accountId) => accountId !== kept.accountId),
+    ),
+  ];
+
+  return {
+    accounts: [kept],
+    removedAccountIds,
+  };
+}
+
+function persistAccounts(accounts: WeixinAccountRecord[]): WeixinAccountRecord[] {
+  ensureDir(DATA_DIR);
+  const normalized = normalizeAccounts(accounts);
+  atomicWrite(ACCOUNTS_PATH, JSON.stringify(normalized.accounts, null, 2));
+  for (const accountId of normalized.removedAccountIds) {
+    deleteWeixinContextTokensByAccount(accountId);
+  }
+  return normalized.accounts;
+}
+
+function readStoredAccounts(): WeixinAccountRecord[] {
+  ensureDir(DATA_DIR);
+  const raw = readJson<unknown>(ACCOUNTS_PATH, []);
+  return Array.isArray(raw) ? raw as WeixinAccountRecord[] : [];
+}
+
+function readAccounts(): WeixinAccountRecord[] {
+  return normalizeAccounts(readStoredAccounts()).accounts;
+}
+
+function writeAccounts(accounts: WeixinAccountRecord[]): void {
+  persistAccounts(accounts);
+}
+
+function readContextTokens(): Record<string, string> {
+  ensureDir(DATA_DIR);
+  return readJson<Record<string, string>>(CONTEXT_TOKENS_PATH, {});
+}
+
+function writeContextTokens(tokens: Record<string, string>): void {
+  ensureDir(DATA_DIR);
+  atomicWrite(CONTEXT_TOKENS_PATH, JSON.stringify(tokens, null, 2));
+}
+
+function contextKey(accountId: string, peerUserId: string): string {
+  return `${accountId}::${peerUserId}`;
+}
+
+export function listWeixinAccounts(): WeixinAccountRecord[] {
+  return readAccounts().sort((a, b) => b.createdAt.localeCompare(a.createdAt));
+}
+
+export function getWeixinAccount(accountId: string): WeixinAccountRecord | undefined {
+  return readAccounts().find((account) => account.accountId === accountId);
+}
+
+export function upsertWeixinAccount(params: {
+  accountId: string;
+  userId?: string;
+  baseUrl?: string;
+  cdnBaseUrl?: string;
+  token?: string;
+  name?: string;
+  enabled?: boolean;
+}): WeixinAccountRecord {
+  const accounts = readAccounts();
+  const existing = accounts.find((account) => account.accountId === params.accountId);
+  const timestamp = now();
+
+  const account: WeixinAccountRecord = existing
+    ? {
+        ...existing,
+        userId: params.userId ?? existing.userId,
+        baseUrl: params.baseUrl ?? existing.baseUrl,
+        cdnBaseUrl: params.cdnBaseUrl ?? existing.cdnBaseUrl,
+        token: params.token ?? existing.token,
+        name: params.name ?? existing.name,
+        enabled: params.enabled ?? existing.enabled,
+        lastLoginAt: timestamp,
+        updatedAt: timestamp,
+      }
+    : {
+        accountId: params.accountId,
+        userId: params.userId ?? '',
+        baseUrl: params.baseUrl ?? DEFAULT_BASE_URL,
+        cdnBaseUrl: params.cdnBaseUrl ?? DEFAULT_CDN_BASE_URL,
+        token: params.token ?? '',
+        name: params.name ?? params.accountId,
+        enabled: params.enabled ?? true,
+        lastLoginAt: timestamp,
+        createdAt: timestamp,
+        updatedAt: timestamp,
+      };
+
+  const nextAccounts = [
+    account,
+    ...accounts.filter((item) => item.accountId !== account.accountId),
+  ];
+  writeAccounts(nextAccounts);
+  return account;
+}
+
+export function deleteWeixinAccount(accountId: string): boolean {
+  const accounts = readAccounts();
+  const nextAccounts = accounts.filter((account) => account.accountId !== accountId);
+  if (nextAccounts.length === accounts.length) {
+    return false;
+  }
+  writeAccounts(nextAccounts);
+  deleteWeixinContextTokensByAccount(accountId);
+  return true;
+}
+
+export function setWeixinAccountEnabled(accountId: string, enabled: boolean): boolean {
+  const accounts = readAccounts();
+  let changed = false;
+  const nextAccounts = accounts.map((account) => {
+    if (account.accountId !== accountId) return account;
+    changed = true;
+    return {
+      ...account,
+      enabled,
+      updatedAt: now(),
+    };
+  });
+
+  if (changed) {
+    writeAccounts(nextAccounts);
+  }
+  return changed;
+}
+
+export function getWeixinContextToken(accountId: string, peerUserId: string): string | undefined {
+  const tokens = readContextTokens();
+  return tokens[contextKey(accountId, peerUserId)];
+}
+
+export function upsertWeixinContextToken(accountId: string, peerUserId: string, contextToken: string): void {
+  const tokens = readContextTokens();
+  tokens[contextKey(accountId, peerUserId)] = contextToken;
+  writeContextTokens(tokens);
+}
+
+export function deleteWeixinContextTokensByAccount(accountId: string): void {
+  const tokens = readContextTokens();
+  const nextTokens = Object.fromEntries(
+    Object.entries(tokens).filter(([key]) => !key.startsWith(`${accountId}::`)),
+  );
+  writeContextTokens(nextTokens);
+}
+
+export function getWeixinAccountsFilePath(): string {
+  return ACCOUNTS_PATH;
+}


### PR DESCRIPTION
## Summary

- **Inbound non-image file support**: PDF, CSV, and other document files sent via Feishu are now properly received. Previously, only image files were handled — non-image files were silently dropped because both `SDKLLMProvider` and `CodexProvider` filtered for image MIME types only. Now, non-image files are saved to disk and their paths are injected into the prompt so Claude can read them with the Read tool.
- **Outbound file sending**: When Claude creates image or document files during a conversation (via Write/Edit tools), they are automatically uploaded and sent back to the Feishu chat as separate image/file messages.
- **`BaseChannelAdapter.sendFile()`**: New optional method for adapters to implement file sending. Default returns unsupported; Feishu adapter implements it using `im.image.create` (images, 10MB max) and `im.file.create` (documents, 30MB max).
- **`ConversationResult.createdFiles`**: Tracks file paths created by Claude during streaming, filtered to sendable types (images + common document formats).

## Key changes

| File | Change |
|------|--------|
| `src/lib/bridge/conversation-engine.ts` | `extractCreatedFiles()`, `isSendableFile()`, `isImageFile()`, `createdFiles` tracking, `filePath` back-population |
| `src/lib/bridge/channel-adapter.ts` | `sendFile()` default method |
| `src/lib/bridge/adapters/feishu-adapter.ts` | `uploadAndSendImage()`, `uploadAndSendFile()`, size limit constants |
| `src/lib/bridge/bridge-manager.ts` | Post-response file sending loop with audit logging |
| `src/llm-provider.ts` | Non-image file path injection into prompt |
| `src/codex-provider.ts` | Non-image file path injection into prompt |

## Test plan

- [x] Send image to Feishu bot → correctly recognized and described
- [x] Send PDF to Feishu bot → correctly read via Read tool and analyzed
- [x] Claude creates image file → automatically sent back to Feishu chat
- [ ] Claude creates document file (PDF, CSV) → sent back as file message
- [ ] Verify file size limits are enforced (10MB image, 30MB file)
- [x] Unit tests pass for `extractCreatedFiles`, `isSendableFile`, `isImageFile`

🤖 Generated with [Claude Code](https://claude.com/claude-code)