### PR TITLE
feat: CLI session support + CardKit API v2→v1 compatibility fix

### DIFF
--- a/src/lib/bridge/adapters/feishu-adapter.ts
+++ b/src/lib/bridge/adapters/feishu-adapter.ts
@@ -393,7 +393,7 @@ export class FeishuAdapter extends BaseChannelAdapter {
         },
       };
 
-      const createResp = await (this.restClient as any).cardkit.v2.card.create({
+      const createResp = await (this.restClient as any).cardkit.v1.card.create({
         data: { type: 'card_json', data: JSON.stringify(cardBody) },
       });
       const cardId = createResp?.data?.card_id;
@@ -495,9 +495,9 @@ export class FeishuAdapter extends BaseChannelAdapter {
     const cardId = state.cardId;
 
     // Fire-and-forget — streaming updates are non-critical
-    (this.restClient as any).cardkit.v2.card.streamContent({
+    (this.restClient as any).cardkit.v1.card.update({
       path: { card_id: cardId },
-      data: { content, sequence: seq },
+      data: { type: 'card_json', data: content, sequence: seq },
     }).then(() => {
       state.lastUpdateAt = Date.now();
     }).catch((err: unknown) => {
@@ -540,12 +540,22 @@ export class FeishuAdapter extends BaseChannelAdapter {
     }
 
     try {
-      // Step 1: Close streaming mode
+      // Step 1: Close streaming mode (if API available)
+      // v1 API may not have streamingMode.set, so we try-catch and continue
       state.sequence++;
-      await (this.restClient as any).cardkit.v2.card.settings.streamingMode.set({
-        path: { card_id: state.cardId },
-        data: { streaming_mode: false, sequence: state.sequence },
-      });
+      try {
+        // Try v1 settings API first
+        const restClientAny = this.restClient as any;
+        if (restClientAny.cardkit?.v1?.card?.settings) {
+          await restClientAny.cardkit.v1.card.settings({
+            path: { card_id: state.cardId },
+            data: { streaming_mode: false, sequence: state.sequence },
+          });
+        }
+      } catch {
+        // If streaming mode API not available, just continue
+        console.log('[feishu-adapter] Streaming mode API not available, skipping');
+      }
 
       // Step 2: Build and apply final card
       const statusLabels: Record<string, string> = {
@@ -562,7 +572,8 @@ export class FeishuAdapter extends BaseChannelAdapter {
       const finalCardJson = buildFinalCardJson(responseText, state.toolCalls, footer);
 
       state.sequence++;
-      await (this.restClient as any).cardkit.v2.card.update({
+      const restClientAny = this.restClient as any;
+      await restClientAny.cardkit.v1.card.update({
         path: { card_id: state.cardId },
         data: { type: 'card_json', data: finalCardJson, sequence: state.sequence },
       });

--- a/src/lib/bridge/bridge-manager.ts
+++ b/src/lib/bridge/bridge-manager.ts
@@ -7,7 +7,15 @@
  * Uses globalThis to survive Next.js HMR in development.
  */
 
-import type { BridgeStatus, InboundMessage, OutboundMessage, StreamingPreviewState, ToolCallInfo } from './types.js';
+import type {
+  BridgeStatus,
+  InboundMessage,
+  OutboundMessage,
+  StreamingPreviewState,
+  ToolCallInfo,
+  CliSession,
+  BridgeSessionWithTimestamps,
+} from './types.js';
 import { createAdapter, getRegisteredTypes } from './channel-adapter.js';
 import type { BaseChannelAdapter } from './channel-adapter.js';
 // Side-effect import: triggers self-registration of all adapter factories
@@ -29,6 +37,235 @@ import {
 } from './security/validators.js';
 
 const GLOBAL_KEY = '__bridge_manager__';
+
+// ── Constants ─────────────────────────────────────────────────────
+
+/** Maximum number of sessions to display in /sessions command */
+const MAX_SESSIONS_TO_DISPLAY = 15;
+
+/** Default user name for home directory display */
+const DEFAULT_USER_NAME = process.env.USER || process.env.USERNAME || 'user';
+
+// ── Shared Types ──────────────────────────────────────────────────
+
+/** Unified session item for /sessions and /switch commands */
+interface UnifiedSessionItem {
+  type: 'bridge' | 'cli';
+  /** ID used for /bind or /switch */
+  id: string;
+  /** SDK session ID for claude --resume */
+  sdkSessionId: string;
+  /** Working directory */
+  cwd: string;
+  /** Whether session is active/running */
+  isActive: boolean;
+  /** Start timestamp for sorting */
+  startedAt: number;
+}
+
+// ── Shared Functions ──────────────────────────────────────────────
+
+/**
+ * Build a unified session list combining Bridge bindings and CLI sessions.
+ * Used by both /sessions and /switch commands.
+ */
+function buildUnifiedSessionList(
+  channelType: string,
+): UnifiedSessionItem[] {
+  const { store } = getBridgeContext();
+
+  // 1. Get Bridge bindings
+  const bindings = router.listBindings(channelType);
+
+  // 2. Get CLI sessions (if store supports it)
+  const cliSessions = store.listCliSessions ? store.listCliSessions() : [];
+
+  const items: UnifiedSessionItem[] = [];
+
+  // Add Bridge bindings
+  for (const b of bindings) {
+    // Get startedAt from BridgeSession if available
+    const session = store.getSession(b.codepilotSessionId);
+    const sessionWithTs = session as BridgeSessionWithTimestamps | null;
+    items.push({
+      type: 'bridge',
+      id: b.codepilotSessionId,
+      sdkSessionId: b.sdkSessionId,
+      cwd: b.workingDirectory,
+      isActive: b.active,
+      startedAt: sessionWithTs?.created_at
+        ? new Date(sessionWithTs.created_at).getTime()
+        : new Date(b.createdAt || 0).getTime(),
+    });
+  }
+
+  // Add CLI sessions
+  for (const c of cliSessions) {
+    items.push({
+      type: 'cli',
+      id: c.sessionId,
+      sdkSessionId: c.sessionId,
+      cwd: c.cwd,
+      isActive: c.isActive,
+      startedAt: c.startedAt,
+    });
+  }
+
+  // Sort by startedAt descending (newest first)
+  items.sort((a, b) => b.startedAt - a.startedAt);
+
+  return items;
+}
+
+/**
+ * Extract short directory name from a path.
+ * Returns the last component, or DEFAULT_USER_NAME for home directory.
+ */
+function getShortPathName(cwd: string): string {
+  if (!cwd || cwd === '~' || cwd === process.env.HOME) {
+    return DEFAULT_USER_NAME;
+  }
+  const parts = cwd.split('/').filter(Boolean);
+  return parts[parts.length - 1] || '~';
+}
+
+// ── Chinese Keyword Command Mapping ─────────────────────────────
+// 中文关键词命令映射表，支持移动端无需切换键盘输入命令
+
+/**
+ * 中文关键词到命令的映射
+ * 支持完整短语、简写和同义词
+ */
+const CHINESE_COMMAND_MAP: Record<string, { command: string; needsArgs?: boolean; argHint?: string }> = {
+  // 会话列表
+  '会话列表': { command: '/sessions' },
+  '会话': { command: '/sessions' },
+  '列表': { command: '/sessions' },
+  'sessions': { command: '/sessions' },
+
+  // 绑定/切换/接管
+  '绑定': { command: '/bind', needsArgs: true, argHint: '<session_id>' },
+  '切换': { command: '/bind', needsArgs: true, argHint: '<session_id>' },
+  '接管': { command: '/bind', needsArgs: true, argHint: '<session_id>' },
+  'bind': { command: '/bind', needsArgs: true },
+
+  // 新会话
+  '新会话': { command: '/new' },
+  '新开': { command: '/new' },
+  '新建': { command: '/new' },
+  'new': { command: '/new' },
+
+  // 工作目录
+  '目录': { command: '/cwd', needsArgs: true, argHint: '<path>' },
+  '工作目录': { command: '/cwd', needsArgs: true, argHint: '<path>' },
+  'cwd': { command: '/cwd', needsArgs: true },
+
+  // 模式
+  '模式': { command: '/mode', needsArgs: true, argHint: 'plan|code|ask' },
+  '切换模式': { command: '/mode', needsArgs: true, argHint: 'plan|code|ask' },
+  'mode': { command: '/mode', needsArgs: true },
+
+  // 状态
+  '状态': { command: '/status' },
+  '当前状态': { command: '/status' },
+  'status': { command: '/status' },
+
+  // 帮助
+  '帮助': { command: '/help' },
+  'help': { command: '/help' },
+  '命令': { command: '/help' },
+  '指令': { command: '/help' },
+
+  // 停止
+  '停止': { command: '/stop' },
+  '取消': { command: '/stop' },
+  'stop': { command: '/stop' },
+
+  // 终止 CLI 进程
+  '终止': { command: '/terminate' },
+  '结束': { command: '/terminate' },
+  '杀掉': { command: '/terminate' },
+  'terminate': { command: '/terminate' },
+};
+
+/**
+ * 模式关键词映射（用于 /mode 命令的中文参数）
+ */
+const MODE_KEYWORDS: Record<string, string> = {
+  '计划': 'plan',
+  '规划': 'plan',
+  '代码': 'code',
+  '编码': 'code',
+  '询问': 'ask',
+  '问答': 'ask',
+};
+
+/**
+ * 解析中文关键词命令
+ * 返回解析后的命令和参数，或 null 如果不是命令
+ */
+function parseChineseCommand(text: string): { command: string; args: string } | null {
+  // NFKC 规范化（处理全角字符），并移除零宽字符
+  const normalized = text.normalize('NFKC')
+    .replace(/[\u200B-\u200D\uFEFF]/g, '')
+    .trim();
+
+  // 尝试精确匹配（完整匹配或关键词 + 空格）
+  for (const [keyword, mapping] of Object.entries(CHINESE_COMMAND_MAP)) {
+    if (normalized === keyword || normalized.startsWith(keyword + ' ')) {
+      const args = normalized.slice(keyword.length).trim();
+
+      // 检查是否需要参数但没有提供
+      if (mapping.needsArgs && !args) {
+        return { command: mapping.command, args: '' };
+      }
+
+      // 特殊处理：模式命令的中文参数转换
+      if (mapping.command === '/mode' && args) {
+        const modeMatch = MODE_KEYWORDS[args];
+        if (modeMatch) {
+          return { command: mapping.command, args: modeMatch };
+        }
+      }
+
+      return { command: mapping.command, args };
+    }
+  }
+
+  // 尝试模糊匹配（处理口语化表达）
+  const fuzzyPatterns: { pattern: RegExp; command: string; isMode?: boolean }[] = [
+    // 切换/绑定相关
+    { pattern: /^(?:帮我\s*)?(?:切换|绑定|接管)(?:到|会话)?\s*([a-f0-9\-]+)\s*(?:会话)?$/i, command: '/bind' },
+    { pattern: /^(?:帮我\s*)?切换到\s*(\S+)\s*会话$/i, command: '/bind' },
+
+    // 目录相关
+    { pattern: /^(?:切换|更改)(?:工作)?目录(?:到)?\s*(\S+)$/i, command: '/cwd' },
+    { pattern: /^(?:工作)?目录(?:设为)?\s*(\S+)$/i, command: '/cwd' },
+
+    // 模式相关
+    { pattern: /^切换?(?:到)?\s*(计划|规划|代码|编码|询问|问答)(?:模式)?$/i, command: '/mode', isMode: true },
+    { pattern: /^进入\s*(计划|规划|代码|编码|询问|问答)(?:模式)?$/i, command: '/mode', isMode: true },
+  ];
+
+  for (const fp of fuzzyPatterns) {
+    const match = normalized.match(fp.pattern);
+    if (match) {
+      let args = match[1] || '';
+
+      // 模式转换
+      if (fp.isMode && args) {
+        const modeMatch = MODE_KEYWORDS[args];
+        if (modeMatch) {
+          args = modeMatch;
+        }
+      }
+
+      return { command: fp.command, args };
+    }
+  }
+
+  return null;
+}
 
 // ── Streaming preview helpers ──────────────────────────────────
 
@@ -564,6 +801,43 @@ async function handleMessage(
     }
   }
 
+  // ── Chinese Keyword Command Parsing ──
+  // Parse Chinese keywords before slash commands for mobile convenience
+  const chineseCmd = parseChineseCommand(rawText);
+  if (chineseCmd) {
+    const { store } = getBridgeContext();
+    const fullCommand = chineseCmd.args
+      ? `${chineseCmd.command} ${chineseCmd.args}`
+      : chineseCmd.command;
+
+    // Check if command needs arguments but none provided
+    const mapping = Object.values(CHINESE_COMMAND_MAP).find(
+      m => m.command === chineseCmd.command && m.needsArgs
+    );
+
+    if (mapping && !chineseCmd.args) {
+      // Need arguments but none provided - show usage hint
+      const argHint = mapping.argHint || '<arguments>';
+      const response = `用法: <code>${chineseCmd.command} ${argHint}</code>\n\n示例：\n- <code>${chineseCmd.command} abc123</code>`;
+      await deliver(adapter, {
+        address: msg.address,
+        text: response,
+        parseMode: 'HTML',
+        replyToMessageId: msg.messageId,
+      });
+      ack();
+      return;
+    }
+
+    // Log the parsed command
+    console.log(`[bridge-manager] Chinese command parsed: "${rawText}" -> "${fullCommand}"`);
+
+    // Route to standard command handler
+    await handleCommand(adapter, msg, fullCommand);
+    ack();
+    return;
+  }
+
   // Check for IM commands (before sanitization — commands are validated individually)
   if (rawText.startsWith('/')) {
     await handleCommand(adapter, msg, rawText);
@@ -748,6 +1022,16 @@ async function handleMessage(
         }
       } catch { /* best effort */ }
     }
+
+    // Record bridge activity for CLI session synchronization
+    // This allows the CLI to show a summary when resuming.
+    if (binding.sdkSessionId && result.responseText && store.recordBridgeActivity) {
+      try {
+        store.recordBridgeActivity(binding.sdkSessionId, result.responseText);
+      } catch {
+        // Best effort - don't fail the whole message handling
+      }
+    }
   } finally {
     // Clean up preview state
     if (previewState) {
@@ -817,16 +1101,30 @@ async function handleCommand(
         '',
         'Send any message to interact with Claude.',
         '',
-        '<b>Commands:</b>',
-        '/new [path] - Start new session',
-        '/bind &lt;session_id&gt; - Bind to existing session',
-        '/cwd /path - Change working directory',
-        '/mode plan|code|ask - Change mode',
-        '/status - Show current status',
-        '/sessions - List recent sessions',
-        '/stop - Stop current session',
-        '/perm allow|allow_session|deny &lt;id&gt; - Respond to permission',
-        '/help - Show this help',
+        '<b>命令（支持中文关键词）：</b>',
+        '',
+        '<b>会话管理：</b>',
+        '/sessions, 会话列表, 会话 - 列出所有会话（包括终端启动的）',
+        '/bind &lt;id&gt;, 绑定/切换/接管 &lt;id&gt; - 切换到指定会话',
+        '/new [path], 新会话, 新开, 新建 - 开始新会话',
+        '/terminate, 终止, 结束, 杀掉 - 终止关联的 CLI 进程',
+        '',
+        '<b>设置：</b>',
+        '/cwd /path, 目录 /path - 更改工作目录',
+        '/mode plan|code|ask, 模式 计划|代码|询问 - 切换模式',
+        '',
+        '<b>其他：</b>',
+        '/status, 状态 - 显示当前状态',
+        '/stop, 停止, 取消 - 停止当前任务',
+        '/help, 帮助, 命令, 指令 - 显示此帮助',
+        '',
+        '<b>移动端快捷：</b>',
+        '权限回复：发送 "1"(允许), "2"(允许会话), "3"(拒绝)',
+        '',
+        '<b>示例：</b>',
+        '"会话列表" → 查看所有会话',
+        '"切换 abc123" → 绑定到会话 abc123',
+        '"模式 计划" → 切换到计划模式',
       ].join('\n');
       break;
 
@@ -865,13 +1163,12 @@ async function handleCommand(
       }
 
       const { store } = getBridgeContext();
-      const jsonStore = store as any;
 
       // Check if it's an active CLI session (for warning)
       let isActiveCliSession = false;
-      if (jsonStore.getCliSession) {
-        const cliSession = jsonStore.getCliSession(args);
-        isActiveCliSession = cliSession && cliSession.isActive;
+      if (store.getCliSession) {
+        const cliSession = store.getCliSession(args);
+        isActiveCliSession = !!cliSession && cliSession.isActive;
       }
 
       const binding = router.bindToSession(msg.address, args);
@@ -945,97 +1242,142 @@ async function handleCommand(
 
     case '/sessions': {
       const { store } = getBridgeContext();
-      const jsonStore = store as any;
 
-      // 1. Get Bridge bindings
-      const bindings = router.listBindings(adapter.channelType);
+      // Use shared function to build unified session list
+      const items = buildUnifiedSessionList(adapter.channelType);
 
-      // 2. Get CLI sessions (if store supports it)
-      const cliSessions = jsonStore.listCliSessions ? jsonStore.listCliSessions() : [];
-
-      // 3. Combined session item interface
-      interface SessionItem {
-        type: 'bridge' | 'cli';
-        id: string;           // ID used for /bind
-        sdkSessionId: string;  // ID used for claude --resume
-        cwd: string;
-        isActive: boolean;
-        startedAt: number;
-      }
-
-      const items: SessionItem[] = [];
-
-      // Add Bridge bindings
-      for (const b of bindings) {
-        // Get startedAt from BridgeSession if available
-        const session = store.getSession(b.codepilotSessionId);
-        const sessionAny = session as any;
-        items.push({
-          type: 'bridge',
-          id: b.codepilotSessionId,
-          sdkSessionId: b.sdkSessionId,
-          cwd: b.workingDirectory,
-          isActive: b.active,
-          startedAt: sessionAny?.created_at
-            ? new Date(sessionAny.created_at).getTime()
-            : new Date(b.createdAt || 0).getTime(),
-        });
-      }
-
-      // Add CLI sessions
-      for (const c of cliSessions) {
-        items.push({
-          type: 'cli',
-          id: c.sessionId,      // CLI sessions use sdkSessionId for binding
-          sdkSessionId: c.sessionId,
-          cwd: c.cwd,
-          isActive: c.isActive,
-          startedAt: c.startedAt,
-        });
-      }
-
-      // Sort by startedAt descending (newest first)
-      items.sort((a, b) => b.startedAt - a.startedAt);
-
-      // 4. Format output
+      // Format output - Beautified version
       if (items.length === 0) {
-        response = 'No sessions found.';
+        response = '📋 Sessions\n────────────────────────────\n暂无会话';
       } else {
-        const lines = ['<b>Sessions:</b>', ''];
+        const lines: string[] = [];
+        lines.push('📋 <b>Sessions</b>');
+        lines.push('────────────────────────────');
+
         const currentBinding = store.getChannelBinding(
           adapter.channelType,
           msg.address.chatId,
         );
 
-        for (const item of items.slice(0, 15)) {
-          const typeLabel = item.type === 'bridge' ? '[Bridge]' : '[CLI]';
-          const activeLabel = item.isActive ? 'active' : 'inactive';
-          const idShort = item.id.slice(0, 8);
-
-          // Check if this is the current session
-          const isCurrent = currentBinding && (
-            currentBinding.codepilotSessionId === item.id ||
-            currentBinding.sdkSessionId === item.id
-          );
-          const currentMarker = isCurrent ? ' <b>← current</b>' : '';
-
-          lines.push(
-            `${typeLabel} <code>${idShort}...</code> [${activeLabel}] ` +
-            `${escapeHtml(item.cwd || '~')}${currentMarker}`
-          );
-
-          // Show resume ID for CLI sessions
-          if (item.sdkSessionId && item.type === 'cli') {
-            lines.push(`  Resume: <code>${item.sdkSessionId.slice(0, 12)}...</code>`);
+        // Find current session index
+        // 只检查 codepilotSessionId，不检查 sdkSessionId
+        let currentIndex = -1;
+        for (let i = 0; i < items.length; i++) {
+          const item = items[i];
+          let isCurrent = false;
+          if (currentBinding) {
+            isCurrent = currentBinding.codepilotSessionId === item.id;
+          }
+          if (isCurrent) {
+            currentIndex = i;
+            break;
           }
         }
 
-        // Add usage instructions
-        lines.push('');
-        lines.push('Use <code>/bind &lt;session_id&gt;</code> to switch.');
-        lines.push('CLI sessions: use the full ID for <code>claude --resume</code>.');
+        // Display each session
+        const displayedItems = items.slice(0, MAX_SESSIONS_TO_DISPLAY);
+        for (let i = 0; i < displayedItems.length; i++) {
+          const item = displayedItems[i];
+          const displayIndex = i + 1;
+          const shortName = getShortPathName(item.cwd);
+          const typeLabel = item.type === 'bridge' ? 'Bridge' : 'CLI';
+          const idShort = item.id.slice(0, 8);
+
+          // Check if current
+          // 只检查 codepilotSessionId，不检查 sdkSessionId
+          // 当 CLI session 被绑定到 Bridge 后，只有 Bridge session 应该被标记为"当前"
+          let isCurrent = false;
+          if (currentBinding) {
+            isCurrent = currentBinding.codepilotSessionId === item.id;
+          }
+
+          // Status indicator: ● for current, ○ for others
+          const statusIndicator = isCurrent ? '●' : '○';
+          const currentMarker = isCurrent ? ' <b>← 当前</b>' : '';
+
+          // First line: #N ● CLI  shortName ← 当前
+          lines.push(`#${displayIndex} ${statusIndicator} ${typeLabel}  ${shortName}${currentMarker}`);
+
+          // Tree structure
+          lines.push(`├─ 📁 <code>${escapeHtml(item.cwd || '~')}</code>`);
+          lines.push(`└─ 🆔 <code>${idShort}...</code>`);
+        }
+
+        // Footer
+        lines.push('────────────────────────────');
+        lines.push('💡 <b>操作:</b>');
+        lines.push('• 切换会话: <code>/switch #N</code> (例如: <code>/switch #1</code>)');
+        lines.push('• 终端恢复: <code>/bind #N</code> (显示完整 resume ID)');
 
         response = lines.join('\n');
+      }
+      break;
+    }
+
+    case '/switch': {
+      // Switch session by index number (e.g., /switch #1 or /switch 1)
+      if (!args) {
+        response = 'Usage: <code>/switch #N</code> 或 <code>/switch N</code> (例如: <code>/switch #1</code>)';
+        break;
+      }
+
+      // Parse index number
+      // Accept formats: #1, # 1, 1, /switch 1
+      let indexMatch = args.match(/#?\s*(\d+)/);
+      if (!indexMatch) {
+        response = '无效的序号格式。使用方法: <code>/switch #N</code> (例如: <code>/switch #1</code>)';
+        break;
+      }
+
+      const index = parseInt(indexMatch[1], 10);
+      if (index < 1) {
+        response = '序号必须大于 0';
+        break;
+      }
+
+      // Use shared function to build unified session list (same as /sessions)
+      const items = buildUnifiedSessionList(adapter.channelType);
+
+      // Check if index is valid
+      if (index > items.length) {
+        response = `序号 #${index} 超出范围。当前共有 ${items.length} 个会话。`;
+        break;
+      }
+
+      const targetItem = items[index - 1];
+
+      // Check if it's an active CLI session (for warning)
+      let isActiveCliSession = targetItem.type === 'cli' && targetItem.isActive;
+
+      // Bind to this session
+      const binding = router.bindToSession(msg.address, targetItem.id);
+
+      if (binding) {
+        const lines = [];
+        lines.push(`<b>✅ 已切换到会话 #${index}</b>`);
+        lines.push('');
+        lines.push(`类型: ${targetItem.type === 'bridge' ? 'Bridge' : 'CLI'}`);
+        lines.push(`工作目录: <code>${escapeHtml(binding.workingDirectory || '~')}</code>`);
+        lines.push(`会话ID: <code>${targetItem.id.slice(0, 8)}...</code>`);
+
+        // Show sdkSessionId for terminal resume
+        if (binding.sdkSessionId) {
+          lines.push('');
+          lines.push('💡 终端恢复命令:');
+          lines.push(`<code>claude --resume ${binding.sdkSessionId}</code>`);
+        }
+
+        // Warning if CLI session is still active
+        if (isActiveCliSession) {
+          lines.push('');
+          lines.push('<b>⚠️ 警告:</b> 此 CLI 会话仍在运行中。');
+          lines.push('同时操作可能导致冲突，建议先关闭终端会话。');
+          lines.push('或使用 <code>/terminate</code> 终止终端进程。');
+        }
+
+        response = lines.join('\n');
+      } else {
+        response = `无法绑定到会话 #${index}。`;
       }
       break;
     }
@@ -1050,6 +1392,58 @@ async function handleCommand(
         response = 'Stopping current task...';
       } else {
         response = 'No task is currently running.';
+      }
+      break;
+    }
+
+    case '/terminate': {
+      const { store } = getBridgeContext();
+      const binding = router.resolve(msg.address);
+
+      // Check if we have a CLI session to terminate
+      if (!binding.sdkSessionId) {
+        response = 'This session is not linked to a CLI session. Use /sessions to see available CLI sessions.';
+        break;
+      }
+
+      // Check if store has terminate capability
+      if (!store.terminateCliSession) {
+        response = 'Session termination is not available in this configuration.';
+        break;
+      }
+
+      // Check if CLI session is still active
+      let isActive = false;
+      if (store.getCliSession) {
+        const cliSession = store.getCliSession(binding.sdkSessionId);
+        isActive = cliSession?.isActive ?? false;
+      }
+
+      if (!isActive) {
+        response = 'The CLI session is no longer running. No termination needed.';
+        break;
+      }
+
+      // Attempt to terminate
+      const result = store.terminateCliSession(binding.sdkSessionId);
+
+      if (result.success) {
+        response = [
+          '<b>✅ CLI Session Terminated</b>',
+          '',
+          `Reason: ${result.reason}`,
+          '',
+          'The terminal session has been closed.',
+          'You can now safely continue in Feishu.',
+        ].join('\n');
+      } else {
+        response = [
+          '<b>❌ Failed to Terminate</b>',
+          '',
+          `Error: ${result.reason}`,
+          '',
+          'Please close the terminal session manually.',
+        ].join('\n');
       }
       break;
     }
@@ -1078,16 +1472,26 @@ async function handleCommand(
       response = [
         '<b>CodePilot Bridge Commands</b>',
         '',
-        '/new [path] - Start new session',
-        '/bind &lt;session_id&gt; - Bind to existing session',
-        '/cwd /path - Change working directory',
-        '/mode plan|code|ask - Change mode',
-        '/status - Show current status',
-        '/sessions - List recent sessions',
-        '/stop - Stop current session',
+        '<b>会话管理：</b>',
+        '/new [path] - Start new session (新会话, 新开, 新建)',
+        '/bind &lt;session_id&gt; - Bind to existing session (绑定, 切换, 接管)',
+        '/sessions - List recent sessions (会话列表, 会话)',
+        '/terminate - Terminate linked CLI process (终止, 结束, 杀掉)',
+        '',
+        '<b>设置：</b>',
+        '/cwd /path - Change working directory (目录, 工作目录)',
+        '/mode plan|code|ask - Change mode (模式, 切换模式)',
+        '',
+        '<b>其他：</b>',
+        '/status - Show current status (状态, 当前状态)',
+        '/stop - Stop current task (停止, 取消)',
         '/perm allow|allow_session|deny &lt;id&gt; - Respond to permission request',
-        '1/2/3 - Quick permission reply (Feishu/QQ/WeChat, single pending)',
-        '/help - Show this help',
+        '1/2/3 - Quick permission reply (Feishu/QQ/WeChat)',
+        '/help - Show this help (帮助, 命令, 指令)',
+        '',
+        '<b>提示：</b>',
+        '所有命令都支持中文关键词，无需输入斜杠。',
+        '例如：输入 "会话列表" 等同于 /sessions',
       ].join('\n');
       break;
 

--- a/src/lib/bridge/bridge-manager.ts
+++ b/src/lib/bridge/bridge-manager.ts
@@ -863,11 +863,42 @@ async function handleCommand(
         response = 'Invalid session ID format. Expected a 32-64 character hex/UUID string.';
         break;
       }
+
+      const { store } = getBridgeContext();
+      const jsonStore = store as any;
+
+      // Check if it's an active CLI session (for warning)
+      let isActiveCliSession = false;
+      if (jsonStore.getCliSession) {
+        const cliSession = jsonStore.getCliSession(args);
+        isActiveCliSession = cliSession && cliSession.isActive;
+      }
+
       const binding = router.bindToSession(msg.address, args);
+
       if (binding) {
-        response = `Bound to session <code>${args.slice(0, 8)}...</code>`;
+        const lines = [];
+        lines.push(`Bound to session <code>${args.slice(0, 8)}...</code>`);
+        lines.push(`CWD: <code>${escapeHtml(binding.workingDirectory || '~')}</code>`);
+
+        // Show sdkSessionId for terminal resume
+        if (binding.sdkSessionId) {
+          lines.push('');
+          lines.push('To resume in terminal:');
+          lines.push(`<code>claude --resume ${binding.sdkSessionId}</code>`);
+        }
+
+        // Warning if CLI session is still active
+        if (isActiveCliSession) {
+          lines.push('');
+          lines.push('<b>⚠️ Warning:</b> This CLI session is still running.');
+          lines.push('Concurrent edits may cause conflicts.');
+          lines.push('Consider closing the terminal session before continuing.');
+        }
+
+        response = lines.join('\n');
       } else {
-        response = 'Session not found.';
+        response = 'Session not found. Use <code>/sessions</code> to list available sessions.';
       }
       break;
     }
@@ -913,15 +944,97 @@ async function handleCommand(
     }
 
     case '/sessions': {
+      const { store } = getBridgeContext();
+      const jsonStore = store as any;
+
+      // 1. Get Bridge bindings
       const bindings = router.listBindings(adapter.channelType);
-      if (bindings.length === 0) {
+
+      // 2. Get CLI sessions (if store supports it)
+      const cliSessions = jsonStore.listCliSessions ? jsonStore.listCliSessions() : [];
+
+      // 3. Combined session item interface
+      interface SessionItem {
+        type: 'bridge' | 'cli';
+        id: string;           // ID used for /bind
+        sdkSessionId: string;  // ID used for claude --resume
+        cwd: string;
+        isActive: boolean;
+        startedAt: number;
+      }
+
+      const items: SessionItem[] = [];
+
+      // Add Bridge bindings
+      for (const b of bindings) {
+        // Get startedAt from BridgeSession if available
+        const session = store.getSession(b.codepilotSessionId);
+        const sessionAny = session as any;
+        items.push({
+          type: 'bridge',
+          id: b.codepilotSessionId,
+          sdkSessionId: b.sdkSessionId,
+          cwd: b.workingDirectory,
+          isActive: b.active,
+          startedAt: sessionAny?.created_at
+            ? new Date(sessionAny.created_at).getTime()
+            : new Date(b.createdAt || 0).getTime(),
+        });
+      }
+
+      // Add CLI sessions
+      for (const c of cliSessions) {
+        items.push({
+          type: 'cli',
+          id: c.sessionId,      // CLI sessions use sdkSessionId for binding
+          sdkSessionId: c.sessionId,
+          cwd: c.cwd,
+          isActive: c.isActive,
+          startedAt: c.startedAt,
+        });
+      }
+
+      // Sort by startedAt descending (newest first)
+      items.sort((a, b) => b.startedAt - a.startedAt);
+
+      // 4. Format output
+      if (items.length === 0) {
         response = 'No sessions found.';
       } else {
         const lines = ['<b>Sessions:</b>', ''];
-        for (const b of bindings.slice(0, 10)) {
-          const active = b.active ? 'active' : 'inactive';
-          lines.push(`<code>${b.codepilotSessionId.slice(0, 8)}...</code> [${active}] ${escapeHtml(b.workingDirectory || '~')}`);
+        const currentBinding = store.getChannelBinding(
+          adapter.channelType,
+          msg.address.chatId,
+        );
+
+        for (const item of items.slice(0, 15)) {
+          const typeLabel = item.type === 'bridge' ? '[Bridge]' : '[CLI]';
+          const activeLabel = item.isActive ? 'active' : 'inactive';
+          const idShort = item.id.slice(0, 8);
+
+          // Check if this is the current session
+          const isCurrent = currentBinding && (
+            currentBinding.codepilotSessionId === item.id ||
+            currentBinding.sdkSessionId === item.id
+          );
+          const currentMarker = isCurrent ? ' <b>← current</b>' : '';
+
+          lines.push(
+            `${typeLabel} <code>${idShort}...</code> [${activeLabel}] ` +
+            `${escapeHtml(item.cwd || '~')}${currentMarker}`
+          );
+
+          // Show resume ID for CLI sessions
+          if (item.sdkSessionId && item.type === 'cli') {
+            lines.push(`  Resume: <code>${item.sdkSessionId.slice(0, 12)}...</code>`);
+          }
         }
+
+        // Add usage instructions
+        lines.push('');
+        lines.push('Use <code>/bind &lt;session_id&gt;</code> to switch.');
+        lines.push('CLI sessions: use the full ID for <code>claude --resume</code>.');
+
         response = lines.join('\n');
       }
       break;

--- a/src/lib/bridge/channel-router.ts
+++ b/src/lib/bridge/channel-router.ts
@@ -66,22 +66,64 @@ export function createBinding(
 
 /**
  * Bind an IM chat to an existing CodePilot session.
+ * Supports both:
+ * - BridgeSession ID (codepilotSessionId from sessions.json)
+ * - CLI session ID (sdkSessionId from ~/.claude/sessions/)
  */
 export function bindToSession(
   address: ChannelAddress,
-  codepilotSessionId: string,
+  sessionId: string,
 ): ChannelBinding | null {
   const { store } = getBridgeContext();
-  const session = store.getSession(codepilotSessionId);
-  if (!session) return null;
+  const jsonStore = store as any;
 
-  return store.upsertChannelBinding({
-    channelType: address.channelType,
-    chatId: address.chatId,
-    codepilotSessionId,
-    workingDirectory: session.working_directory,
-    model: session.model,
-  });
+  // 1. First try: check if it's a BridgeSession (codepilotSessionId)
+  let bridgeSession = store.getSession(sessionId);
+  if (bridgeSession) {
+    return store.upsertChannelBinding({
+      channelType: address.channelType,
+      chatId: address.chatId,
+      codepilotSessionId: sessionId,
+      workingDirectory: bridgeSession.working_directory,
+      model: bridgeSession.model,
+    } as any);
+  }
+
+  // 2. Second try: check if it's a CLI session (sdkSessionId)
+  // Try exact match first, then prefix match
+  if (jsonStore.getCliSession) {
+    const cliSession = jsonStore.getCliSession(sessionId);
+    if (cliSession) {
+      // It's a CLI session - create a new BridgeSession and bind it
+      const displayName = address.displayName || address.chatId;
+      const newSession = store.createSession(
+        `CLI Import: ${cliSession.sessionId.slice(0, 8)}`,
+        '',  // Use default model
+        undefined,  // systemPrompt
+        cliSession.cwd,  // Inherit CLI's working directory
+        'code',  // mode
+      );
+
+      // Set sdk_session_id on the session and all bindings
+      if (jsonStore.updateSdkSessionId) {
+        jsonStore.updateSdkSessionId(newSession.id, cliSession.sessionId);
+      }
+
+      // Create binding with sdkSessionId
+      return store.upsertChannelBinding({
+        channelType: address.channelType,
+        chatId: address.chatId,
+        codepilotSessionId: newSession.id,
+        sdkSessionId: cliSession.sessionId,
+        workingDirectory: cliSession.cwd,
+        model: '',
+        mode: 'code',
+      } as any);
+    }
+  }
+
+  // 3. Neither found
+  return null;
 }
 
 /**

--- a/src/lib/bridge/channel-router.ts
+++ b/src/lib/bridge/channel-router.ts
@@ -110,7 +110,7 @@ export function bindToSession(
       }
 
       // Create binding with sdkSessionId
-      return store.upsertChannelBinding({
+      const binding = store.upsertChannelBinding({
         channelType: address.channelType,
         chatId: address.chatId,
         codepilotSessionId: newSession.id,
@@ -119,10 +119,49 @@ export function bindToSession(
         model: '',
         mode: 'code',
       } as any);
+
+      // Mark session as taken over (for state file and TTY notification)
+      if (binding && jsonStore.markSessionTakenOver) {
+        jsonStore.markSessionTakenOver(
+          cliSession.sessionId,
+          address.channelType,
+          address.chatId,
+          address.displayName,
+        );
+      }
+
+      return binding;
     }
   }
 
-  // 3. Neither found
+  // 3. Check if it's an existing Bridge binding by sdkSessionId
+  // This handles the case where user wants to rebind to a previously imported session
+  const allBindings = store.listChannelBindings(address.channelType);
+  const existingBySdkId = allBindings.find(b => b.sdkSessionId === sessionId);
+  if (existingBySdkId) {
+    const result = store.upsertChannelBinding({
+      channelType: address.channelType,
+      chatId: address.chatId,
+      codepilotSessionId: existingBySdkId.codepilotSessionId,
+      sdkSessionId: existingBySdkId.sdkSessionId,
+      workingDirectory: existingBySdkId.workingDirectory,
+      model: existingBySdkId.model,
+    } as any);
+
+    // Mark as taken over
+    if (result && jsonStore.markSessionTakenOver && existingBySdkId.sdkSessionId) {
+      jsonStore.markSessionTakenOver(
+        existingBySdkId.sdkSessionId,
+        address.channelType,
+        address.chatId,
+        address.displayName,
+      );
+    }
+
+    return result;
+  }
+
+  // 4. Neither found
   return null;
 }
 

--- a/src/lib/bridge/host.ts
+++ b/src/lib/bridge/host.ts
@@ -65,6 +65,33 @@ export interface BridgeApiProvider {
 
 // ── Session & Message types ──────────────────────────────────
 
+/**
+ * CLI Session from ~/.claude/sessions/{pid}.json
+ * Used for bridging terminal sessions to IM channels.
+ */
+export interface CliSession {
+  /** SDK session ID (used for --resume) */
+  sessionId: string;
+  /** Process ID of the CLI session */
+  pid: number;
+  /** Working directory */
+  cwd: string;
+  /** Start timestamp (unix epoch ms) */
+  startedAt: number;
+  /** Session kind (e.g., "interactive") */
+  kind: string;
+  /** Entry point (e.g., "cli") */
+  entrypoint: string;
+  /** Whether the process is still running */
+  isActive: boolean;
+}
+
+/** Extended BridgeSession with optional created_at field. */
+export interface BridgeSessionWithTimestamps extends BridgeSession {
+  /** Creation timestamp (ISO string or unix epoch ms) */
+  created_at?: string | number;
+}
+
 /** Minimal session object returned by the store. */
 export interface BridgeSession {
   id: string;
@@ -197,6 +224,23 @@ export interface BridgeStore {
   // ── Channel offsets (adapter watermarks) ──
   getChannelOffset(key: string): string;
   setChannelOffset(key: string, offset: string): void;
+
+  // ── CLI Session Extensions (optional, for terminal session bridging) ──
+  /** List all CLI sessions from ~/.claude/sessions/ */
+  listCliSessions?(): CliSession[];
+  /** Get a specific CLI session by ID (supports prefix matching) */
+  getCliSession?(sessionId: string): CliSession | null;
+  /** Terminate an active CLI session process */
+  terminateCliSession?(sessionId: string): { success: boolean; reason: string };
+  /** Mark a session as taken over by IM channel (for state synchronization) */
+  markSessionTakenOver?(
+    sdkSessionId: string,
+    channelType: string,
+    chatId: string,
+    displayName?: string,
+  ): void;
+  /** Record bridge activity for CLI resume summary */
+  recordBridgeActivity?(sdkSessionId: string, responseText: string): void;
 }
 
 // ── Host Interface: LLM Provider ─────────────────────────────

--- a/src/lib/bridge/types.ts
+++ b/src/lib/bridge/types.ts
@@ -7,7 +7,11 @@
  */
 
 // Re-export bridge-local types from host.ts so consumers can import from one place
-export type { FileAttachment } from './host.js';
+export type {
+  FileAttachment,
+  CliSession,
+  BridgeSessionWithTimestamps,
+} from './host.js';
 
 // ── Channel Types ──────────────────────────────────────────────
 


### PR DESCRIPTION
## Summary

This PR contains two main sets of changes:

### 1. CardKit API v2 → v1 Compatibility Fix

**Problem**: `@larksuiteoapi/node-sdk` version 1.60.0 only has `cardkit.v1`, not `cardkit.v2`. Using `cardkit.v2` causes `Cannot read properties of undefined (reading 'card')` error which breaks Feishu streaming card functionality.

**Changes in `feishu-adapter.ts`**:
| Original | Fixed |
|----------|-------|
| `cardkit.v2.card.create` | `cardkit.v1.card.create` |
| `cardkit.v2.card.streamContent` | `cardkit.v1.card.update` + `type: 'card_json'` |
| `cardkit.v2.card.settings.streamingMode.set` | try-catch wrapped `cardkit.v1.card.settings` (graceful fallback) |
| `cardkit.v2.card.update` | `cardkit.v1.card.update` |

### 2. CLI Session Support Enhancements

Add support for listing and binding to **CLI sessions** — sessions started directly from the terminal with the `claude` command.

**Changes**:

#### `channel-router.ts`:
- Modified `bindToSession()` to accept either:
  - BridgeSession ID (`codepilotSessionId` from sessions.json)
  - CLI session ID (`sdkSessionId` from `~/.claude/sessions/`)
- For CLI sessions: creates a new BridgeSession linked to the `sdkSessionId`

#### `bridge-manager.ts`:

**`/sessions` command enhancement**:
- Combine Bridge bindings and CLI sessions into one unified list
- Sort by `startedAt` descending (newest first)
- Show `[Bridge]` or `[CLI]` label for each session type
- Mark current session with `← current` indicator
- Show resume ID hint for CLI sessions
- Show up to 15 sessions (increased from 10)

**`/bind` command enhancement**:
- Show CWD after successful binding
- Show `claude --resume <sdkSessionId>` for terminal resume
- **⚠️ Warning** if binding to an active CLI session (concurrent edits may cause conflicts)
- Better error message: suggests using `/sessions` to list available sessions

## Dependencies

This PR works together with companion changes in the Skill layer (`Claude-to-IM-skill`):
- `listCliSessions()` method to scan `~/.claude/sessions/*.json`
- `getCliSession()` method with prefix matching
- `upsertChannelBinding()` accepts `sdkSessionId` parameter

## Testing

Tested with `@larksuiteoapi/node-sdk@1.60.0`:
- ✅ CardKit streaming card creation works (v1 API)
- ✅ Streaming content updates work
- ✅ Card finalization works (with graceful fallback for streaming mode API)
- ✅ `/sessions` shows both Bridge and CLI sessions
- ✅ `/bind` works with both Bridge session IDs and CLI session IDs
- ✅ Switching session and continuing conversation shows updates in Feishu