### PR TITLE
fix(feishu): disable streaming cards until lark SDK ships cardkit.v2

### DIFF
--- a/package-lock.json
+++ b/package-lock.json
@@ -9,7 +9,7 @@
       "version": "0.1.0",
       "dependencies": {
         "@anthropic-ai/claude-agent-sdk": "^0.2.62",
-        "@larksuiteoapi/node-sdk": "^1.59.0",
+        "@larksuiteoapi/node-sdk": "^1.60.0",
         "discord.js": "^14.25.1",
         "markdown-it": "^14.1.1",
         "ws": "^8.18.0"
@@ -925,9 +925,9 @@
       }
     },
     "node_modules/@larksuiteoapi/node-sdk": {
-      "version": "1.59.0",
-      "resolved": "https://registry.npmjs.org/@larksuiteoapi/node-sdk/-/node-sdk-1.59.0.tgz",
-      "integrity": "sha512-sBpkruTvZDOxnVtoTbepWKRX0j1Y1ZElQYu0x7+v088sI9pcpbVp6ZzCGn62dhrKPatzNyCJyzYCPXPYQWccrA==",
+      "version": "1.60.0",
+      "resolved": "https://registry.npmjs.org/@larksuiteoapi/node-sdk/-/node-sdk-1.60.0.tgz",
+      "integrity": "sha512-MS1eXx7K6HHIyIcCBkJLb21okoa8ZatUGQWZaCCUePm6a37RWFmT6ZKlKvHxAanSX26wNuNlwP0RhgscsE+T6g==",
       "license": "MIT",
       "dependencies": {
         "axios": "~1.13.3",

--- a/package.json
+++ b/package.json
@@ -27,7 +27,10 @@
       "import": "./dist/lib/bridge/security/*.js"
     }
   },
-  "files": ["dist", "src/lib"],
+  "files": [
+    "dist",
+    "src/lib"
+  ],
   "scripts": {
     "build": "tsc -p tsconfig.build.json",
     "prepare": "npm run build",
@@ -38,15 +41,15 @@
   },
   "dependencies": {
     "@anthropic-ai/claude-agent-sdk": "^0.2.62",
-    "@larksuiteoapi/node-sdk": "^1.59.0",
+    "@larksuiteoapi/node-sdk": "^1.60.0",
     "discord.js": "^14.25.1",
     "markdown-it": "^14.1.1",
     "ws": "^8.18.0"
   },
   "devDependencies": {
     "@types/markdown-it": "^14.1.2",
-    "@types/ws": "^8.5.0",
     "@types/node": "^22.0.0",
+    "@types/ws": "^8.5.0",
     "tsx": "^4.21.0",
     "typescript": "^5"
   },

--- a/src/lib/bridge/adapters/feishu-adapter.ts
+++ b/src/lib/bridge/adapters/feishu-adapter.ts
@@ -120,6 +120,16 @@ export class FeishuAdapter extends BaseChannelAdapter {
   private activeCards = new Map<string, FeishuCardState>();
   /** In-flight card creation promises per chatId — prevents duplicate creation. */
   private cardCreatePromises = new Map<string, Promise<boolean>>();
+  /**
+   * Feature flag: streaming cards use cardkit.v2 API which is not yet
+   * implemented in @larksuiteoapi/node-sdk (as of v1.61.0). Setting this
+   * to false disables the streaming card path — bridge-manager falls back
+   * to deliverResponse → sendAsCard/sendAsPost (static final reply).
+   * Flip to true once lark SDK ships cardkit.v2 support.
+   */
+  private static readonly STREAMING_CARDS_ENABLED = false;
+  /** One-shot guard so the disabled-streaming notice only logs once per process. */
+  private streamingCardsDisabledLogged = false;
 
   // ── Lifecycle ───────────────────────────────────────────────
 
@@ -267,7 +277,7 @@ export class FeishuAdapter extends BaseChannelAdapter {
     const messageId = this.lastIncomingMessageId.get(chatId);
 
     // Create streaming card (fire-and-forget — fallback to traditional if fails)
-    if (messageId) {
+    if (messageId && FeishuAdapter.STREAMING_CARDS_ENABLED) {
       this.createStreamingCard(chatId, messageId).catch(() => {});
     }
 
@@ -358,6 +368,14 @@ export class FeishuAdapter extends BaseChannelAdapter {
    * Returns true if card was created successfully.
    */
   private createStreamingCard(chatId: string, replyToMessageId?: string): Promise<boolean> {
+    // Hard-disabled until lark SDK supports cardkit.v2. See STREAMING_CARDS_ENABLED.
+    if (!FeishuAdapter.STREAMING_CARDS_ENABLED) {
+      if (!this.streamingCardsDisabledLogged) {
+        console.log('[feishu-adapter] Streaming cards disabled (cardkit.v2 not in lark SDK) — using static replies');
+        this.streamingCardsDisabledLogged = true;
+      }
+      return Promise.resolve(false);
+    }
     if (!this.restClient || this.activeCards.has(chatId)) return Promise.resolve(false);
 
     // In-flight guard: if creation is already in progress, return the existing promise
@@ -604,6 +622,10 @@ export class FeishuAdapter extends BaseChannelAdapter {
    * Creates streaming card on first call, then updates content.
    */
   onStreamText(chatId: string, fullText: string): void {
+    if (!FeishuAdapter.STREAMING_CARDS_ENABLED) {
+      // Streaming disabled — bridge-manager will deliver final text via send()
+      return;
+    }
     if (!this.activeCards.has(chatId)) {
       // Card should have been created by onMessageStart, but create lazily if not
       const messageId = this.lastIncomingMessageId.get(chatId);
@@ -620,6 +642,11 @@ export class FeishuAdapter extends BaseChannelAdapter {
   }
 
   async onStreamEnd(chatId: string, status: 'completed' | 'interrupted' | 'error', responseText: string): Promise<boolean> {
+    if (!FeishuAdapter.STREAMING_CARDS_ENABLED) {
+      // Return false → bridge-manager treats card as NOT finalized
+      // → falls through to deliverResponse (sendAsCard / sendAsPost).
+      return false;
+    }
     return this.finalizeCard(chatId, status, responseText);
   }
 


### PR DESCRIPTION
## Summary

The Feishu streaming card path calls `restClient.cardkit.v2.*`, but `@larksuiteoapi/node-sdk` only exposes `cardkit.v1` (verified on v1.60.0 — latest at time of writing). Every incoming Feishu message crashes with `Cannot read properties of undefined (reading 'card')` and the bridge ends up replying with `"Error: ..."` prefixes to users.

This PR adds a `STREAMING_CARDS_ENABLED` feature flag (default `false`) that short-circuits the streaming path so `bridge-manager` falls through to the existing static `sendAsCard` / `sendAsPost` delivery. Flip the flag back to `true` once `@larksuiteoapi/node-sdk` ships `cardkit.v2`.

## Changes

- `src/lib/bridge/adapters/feishu-adapter.ts`
  - Add `STREAMING_CARDS_ENABLED` static flag (default `false`)
  - Short-circuit `createStreamingCard` / `onStreamText` / `onStreamEnd` when flag is off
  - Gate the `onMessageStart` streaming card creation behind the flag
  - One-shot log line on first disabled call (prevents the flood of WARN we saw)
- `package.json` / `package-lock.json`
  - Bump `@larksuiteoapi/node-sdk` `^1.59.0` → `^1.60.0` (housekeeping; 1.60 still lacks `cardkit.v2` so the flag is still necessary)

## How to verify `cardkit.v2` is unavailable

```js
const sdk = require('@larksuiteoapi/node-sdk');
const c = new sdk.Client({ appId: 'x', appSecret: 'y' });
console.log(typeof c.cardkit);      // object
console.log(typeof c.cardkit.v2);   // undefined
console.log(Object.keys(c.cardkit)); // [ 'v1' ]
```

## Test plan

- [x] Build with the flag off, send a Feishu message, confirm no `Failed to create streaming card` warnings in logs
- [x] Confirm the final reply is delivered via `sendAsCard` / `sendAsPost` (static card, no streaming preview)
- [x] Confirm the one-shot "Streaming cards disabled" log line appears exactly once per process
- [ ] Re-enable the flag once SDK ships `cardkit.v2` and verify streaming preview works