### PR TITLE
修复飞书流式消息卡片（CardKit API v1 兼容性）

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,0 +1,18 @@
+# Changelog
+
+## 2026-04-22
+
+### Fix: Feishu CardKit API v1 compatibility
+
+Migrated all CardKit API calls from the non-existent `cardkit.v2` to the actual `cardkit.v1` in `@larksuiteoapi/node-sdk` v1.61.1.
+
+**Changes in `src/lib/bridge/adapters/feishu-adapter.ts`:**
+
+| Operation | Before | After |
+|---|---|---|
+| Create card | `cardkit.v2.card.create` | `cardkit.v1.card.create` |
+| Stream content | `cardkit.v2.card.streamContent({ path: { card_id } })` | `cardkit.v1.cardElement.content({ path: { card_id, element_id: 'streaming_content' } })` |
+| Close streaming | `cardkit.v2.card.settings.streamingMode.set({ data: { streaming_mode: false } })` | `cardkit.v1.card.settings({ data: { settings: JSON.stringify({ streaming_mode: false }), sequence } })` |
+| Finalize card | `cardkit.v2.card.update({ data: { type, data, sequence } })` | `cardkit.v1.card.update({ data: { card: { type, data }, sequence } })` |
+
+**Root cause:** `cardkit.v2` does not exist in the SDK — accessing it returned `undefined`, causing `Cannot read properties of undefined (reading 'card')` on every streaming card creation attempt.

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,8 +1,37 @@
 # Changelog
 
-## 2026-04-22
+## 2026-04-22 (session 2)
 
-### Fix: Feishu CardKit API v1 compatibility
+### Feishu streaming card UX improvements
+
+**Anti-flicker: separate streaming elements**
+- Split streaming card into two independent elements: `streaming_content` (response text) and `tool_progress` (tool calls)
+- Text updates no longer re-render the tool list and vice versa
+- Added `buildToolProgressMarkdown` import to `feishu-adapter.ts`
+
+**Tool call details in progress display**
+- `buildToolProgressMarkdown` now shows relevant input details per tool:
+  - `Bash`: first line of command (truncated to 60 chars)
+  - `Read`/`Write`/`Edit`: file path
+  - `Grep`: pattern, `Glob`: pattern, `WebFetch`: URL, `WebSearch`: query
+- `ToolCallInfo` type extended with optional `input` field
+- `OnToolEvent` callback and `bridge-manager` updated to pass `input`
+
+**Newline fix in streaming cards**
+- `flushCardUpdate` now applies `preprocessFeishuMarkdown` before sending content, ensuring code fences have proper newlines
+
+**Green header on streaming and final cards**
+- Both streaming and finalized cards now show `🟢 Answer` header with `template: 'green'`
+
+**Permission card reply threading**
+- Permission cards are now sent as replies to the user's original message (`im.message.reply`) instead of standalone messages, keeping the conversation thread clean
+
+**Permission card cleanup on resolution**
+- After clicking Allow/Allow Session/Deny, the permission card is deleted (`im.message.delete`)
+- "Permission response recorded" confirmation message suppressed for Feishu (card toast is sufficient)
+- `FeishuAdapter.updatePermissionCardResolved()` method added
+
+
 
 Migrated all CardKit API calls from the non-existent `cardkit.v2` to the actual `cardkit.v1` in `@larksuiteoapi/node-sdk` v1.61.1.
 

--- a/package-lock.json
+++ b/package-lock.json
@@ -9,7 +9,7 @@
       "version": "0.1.0",
       "dependencies": {
         "@anthropic-ai/claude-agent-sdk": "^0.2.62",
-        "@larksuiteoapi/node-sdk": "^1.59.0",
+        "@larksuiteoapi/node-sdk": "^1.61.1",
         "discord.js": "^14.25.1",
         "markdown-it": "^14.1.1",
         "ws": "^8.18.0"
@@ -925,9 +925,9 @@
       }
     },
     "node_modules/@larksuiteoapi/node-sdk": {
-      "version": "1.59.0",
-      "resolved": "https://registry.npmjs.org/@larksuiteoapi/node-sdk/-/node-sdk-1.59.0.tgz",
-      "integrity": "sha512-sBpkruTvZDOxnVtoTbepWKRX0j1Y1ZElQYu0x7+v088sI9pcpbVp6ZzCGn62dhrKPatzNyCJyzYCPXPYQWccrA==",
+      "version": "1.61.1",
+      "resolved": "https://registry.npmjs.org/@larksuiteoapi/node-sdk/-/node-sdk-1.61.1.tgz",
+      "integrity": "sha512-BxLBCXk/652I0nWduQbiIrTH2TPe/i4ZD6UhW3VCTVFzrOq5Y9SKvAwanBE6z1ZyEPL6iLnXg/TfGvGSzG6MLw==",
       "license": "MIT",
       "dependencies": {
         "axios": "~1.13.3",

--- a/package.json
+++ b/package.json
@@ -27,7 +27,10 @@
       "import": "./dist/lib/bridge/security/*.js"
     }
   },
-  "files": ["dist", "src/lib"],
+  "files": [
+    "dist",
+    "src/lib"
+  ],
   "scripts": {
     "build": "tsc -p tsconfig.build.json",
     "prepare": "npm run build",
@@ -38,15 +41,15 @@
   },
   "dependencies": {
     "@anthropic-ai/claude-agent-sdk": "^0.2.62",
-    "@larksuiteoapi/node-sdk": "^1.59.0",
+    "@larksuiteoapi/node-sdk": "^1.61.1",
     "discord.js": "^14.25.1",
     "markdown-it": "^14.1.1",
     "ws": "^8.18.0"
   },
   "devDependencies": {
     "@types/markdown-it": "^14.1.2",
-    "@types/ws": "^8.5.0",
     "@types/node": "^22.0.0",
+    "@types/ws": "^8.5.0",
     "tsx": "^4.21.0",
     "typescript": "^5"
   },

--- a/src/lib/bridge/adapters/feishu-adapter.ts
+++ b/src/lib/bridge/adapters/feishu-adapter.ts
@@ -36,6 +36,7 @@ import {
   buildStreamingContent,
   buildFinalCardJson,
   buildPermissionButtonCard,
+  buildToolProgressMarkdown,
   formatElapsed,
 } from '../markdown/feishu.js';
 
@@ -384,6 +385,10 @@ export class FeishuAdapter extends BaseChannelAdapter {
           wide_screen_mode: true,
           summary: { content: '思考中...' },
         },
+        header: {
+          title: { tag: 'plain_text', content: '🟢 Answer' },
+          template: 'green',
+        },
         body: {
           elements: [{
             tag: 'markdown',
@@ -391,6 +396,11 @@ export class FeishuAdapter extends BaseChannelAdapter {
             text_align: 'left',
             text_size: 'normal',
             element_id: 'streaming_content',
+          }, {
+            tag: 'markdown',
+            content: '',
+            text_size: 'normal',
+            element_id: 'tool_progress',
           }],
         },
       };
@@ -490,13 +500,12 @@ export class FeishuAdapter extends BaseChannelAdapter {
     const state = this.activeCards.get(chatId);
     if (!state || !this.restClient) return;
 
-    const content = buildStreamingContent(state.pendingText || '', state.toolCalls);
+    const content = preprocessFeishuMarkdown((state.pendingText || '').trimEnd()) || '💭 Thinking...';
 
     state.sequence++;
     const seq = state.sequence;
     const cardId = state.cardId;
 
-    // Fire-and-forget — streaming updates are non-critical
     (this.restClient as any).cardkit.v1.cardElement.content({
       path: { card_id: cardId, element_id: 'streaming_content' },
       data: { content, sequence: seq },
@@ -507,15 +516,22 @@ export class FeishuAdapter extends BaseChannelAdapter {
     });
   }
 
-  /**
-   * Update tool progress in the streaming card.
-   */
   private updateToolProgress(chatId: string, tools: ToolCallInfo[]): void {
     const state = this.activeCards.get(chatId);
-    if (!state) return;
+    if (!state || !this.restClient) return;
     state.toolCalls = tools;
-    // Trigger a content flush with current text + updated tools
-    this.updateCardContent(chatId, state.pendingText || '');
+
+    const toolMd = buildToolProgressMarkdown(tools);
+    state.sequence++;
+    const seq = state.sequence;
+    const cardId = state.cardId;
+
+    (this.restClient as any).cardkit.v1.cardElement.content({
+      path: { card_id: cardId, element_id: 'tool_progress' },
+      data: { content: toolMd || ' ', sequence: seq },
+    }).catch((err: unknown) => {
+      console.warn('[feishu-adapter] toolProgress update failed:', err instanceof Error ? err.message : err);
+    });
   }
 
   /**
@@ -599,6 +615,16 @@ export class FeishuAdapter extends BaseChannelAdapter {
     return this.activeCards.has(chatId);
   }
 
+  /**
+   * Delete a permission card after the user clicks a button.
+   */
+  updatePermissionCardResolved(messageId: string, _action: string): void {
+    if (!this.restClient || !messageId) return;
+    this.restClient.im.message.delete({
+      path: { message_id: messageId },
+    }).catch(() => { /* best effort */ });
+  }
+
   // ── Streaming adapter interface ────────────────────────────────
 
   /**
@@ -646,7 +672,7 @@ export class FeishuAdapter extends BaseChannelAdapter {
 
     // If there are inline buttons (permission prompts), send card with action buttons
     if (message.inlineButtons && message.inlineButtons.length > 0) {
-      return this.sendPermissionCard(message.address.chatId, text, message.inlineButtons);
+      return this.sendPermissionCard(message.address.chatId, text, message.inlineButtons, message.replyToMessageId);
     }
 
     // Rendering strategy (aligned with Openclaw):
@@ -742,6 +768,7 @@ export class FeishuAdapter extends BaseChannelAdapter {
     chatId: string,
     text: string,
     inlineButtons: import('../types.js').InlineButton[][],
+    replyToMessageId?: string,
   ): Promise<SendResult> {
     if (!this.restClient) {
       return { ok: false, error: 'Feishu client not initialized' };
@@ -771,14 +798,18 @@ export class FeishuAdapter extends BaseChannelAdapter {
       const cardJson = buildPermissionButtonCard(mdText, permId, chatId);
 
       try {
-        const res = await this.restClient.im.message.create({
-          params: { receive_id_type: 'chat_id' },
-          data: {
-            receive_id: chatId,
-            msg_type: 'interactive',
-            content: cardJson,
-          },
-        });
+        let res;
+        if (replyToMessageId) {
+          res = await this.restClient.im.message.reply({
+            path: { message_id: replyToMessageId },
+            data: { msg_type: 'interactive', content: cardJson },
+          });
+        } else {
+          res = await this.restClient.im.message.create({
+            params: { receive_id_type: 'chat_id' },
+            data: { receive_id: chatId, msg_type: 'interactive', content: cardJson },
+          });
+        }
         if (res?.data?.message_id) {
           return { ok: true, messageId: res.data.message_id };
         }

--- a/src/lib/bridge/adapters/feishu-adapter.ts
+++ b/src/lib/bridge/adapters/feishu-adapter.ts
@@ -159,6 +159,8 @@ export class FeishuAdapter extends BaseChannelAdapter {
       'card.action.trigger': (async (data: unknown) => {
         return await this.handleCardAction(data);
       }) as any,
+      'im.message.reaction.created_v1': () => {},
+      'im.message.reaction.deleted_v1': () => {},
     });
 
     // Create and start WSClient
@@ -393,7 +395,7 @@ export class FeishuAdapter extends BaseChannelAdapter {
         },
       };
 
-      const createResp = await (this.restClient as any).cardkit.v2.card.create({
+      const createResp = await (this.restClient as any).cardkit.v1.card.create({
         data: { type: 'card_json', data: JSON.stringify(cardBody) },
       });
       const cardId = createResp?.data?.card_id;
@@ -495,8 +497,8 @@ export class FeishuAdapter extends BaseChannelAdapter {
     const cardId = state.cardId;
 
     // Fire-and-forget — streaming updates are non-critical
-    (this.restClient as any).cardkit.v2.card.streamContent({
-      path: { card_id: cardId },
+    (this.restClient as any).cardkit.v1.cardElement.content({
+      path: { card_id: cardId, element_id: 'streaming_content' },
       data: { content, sequence: seq },
     }).then(() => {
       state.lastUpdateAt = Date.now();
@@ -542,9 +544,9 @@ export class FeishuAdapter extends BaseChannelAdapter {
     try {
       // Step 1: Close streaming mode
       state.sequence++;
-      await (this.restClient as any).cardkit.v2.card.settings.streamingMode.set({
+      await (this.restClient as any).cardkit.v1.card.settings({
         path: { card_id: state.cardId },
-        data: { streaming_mode: false, sequence: state.sequence },
+        data: { settings: JSON.stringify({ streaming_mode: false }), sequence: state.sequence },
       });
 
       // Step 2: Build and apply final card
@@ -562,9 +564,9 @@ export class FeishuAdapter extends BaseChannelAdapter {
       const finalCardJson = buildFinalCardJson(responseText, state.toolCalls, footer);
 
       state.sequence++;
-      await (this.restClient as any).cardkit.v2.card.update({
+      await (this.restClient as any).cardkit.v1.card.update({
         path: { card_id: state.cardId },
-        data: { type: 'card_json', data: finalCardJson, sequence: state.sequence },
+        data: { card: { type: 'card_json', data: finalCardJson }, sequence: state.sequence },
       });
 
       console.log(`[feishu-adapter] Card finalized: cardId=${state.cardId}, status=${status}, elapsed=${formatElapsed(elapsedMs)}`);

--- a/src/lib/bridge/bridge-manager.ts
+++ b/src/lib/bridge/bridge-manager.ts
@@ -459,13 +459,19 @@ async function handleMessage(
   if (msg.callbackData) {
     const handled = broker.handlePermissionCallback(msg.callbackData, msg.address.chatId, msg.callbackMessageId);
     if (handled) {
-      // Send confirmation
-      const confirmMsg: OutboundMessage = {
-        address: msg.address,
-        text: 'Permission response recorded.',
-        parseMode: 'plain',
-      };
-      await deliver(adapter, confirmMsg);
+      if (adapter.channelType === 'feishu' && msg.callbackMessageId) {
+        // Update permission card to resolved state instead of sending a new message
+        const parts = msg.callbackData.split(':');
+        const action = parts[1] || 'allow';
+        (adapter as import('./adapters/feishu-adapter.js').FeishuAdapter).updatePermissionCardResolved?.(msg.callbackMessageId, action);
+      } else {
+        const confirmMsg: OutboundMessage = {
+          address: msg.address,
+          text: 'Permission response recorded.',
+          parseMode: 'plain',
+        };
+        await deliver(adapter, confirmMsg);
+      }
     }
     ack();
     return;
@@ -670,11 +676,10 @@ async function handleMessage(
     try { adapter.onStreamText!(msg.address.chatId, fullText); } catch { /* non-critical */ }
   } : undefined;
 
-  const onToolEvent = hasStreamingCards ? (toolId: string, toolName: string, status: 'running' | 'complete' | 'error') => {
+  const onToolEvent = hasStreamingCards ? (toolId: string, toolName: string, status: 'running' | 'complete' | 'error', input?: Record<string, unknown>) => {
     if (toolName) {
-      toolCallTracker.set(toolId, { id: toolId, name: toolName, status });
+      toolCallTracker.set(toolId, { id: toolId, name: toolName, status, input });
     } else {
-      // tool_result doesn't carry name — update existing entry's status
       const existing = toolCallTracker.get(toolId);
       if (existing) existing.status = status;
     }
@@ -748,6 +753,7 @@ async function handleMessage(
         }
       } catch { /* best effort */ }
     }
+
   } finally {
     // Clean up preview state
     if (previewState) {

--- a/src/lib/bridge/conversation-engine.ts
+++ b/src/lib/bridge/conversation-engine.ts
@@ -43,7 +43,7 @@ export type OnPartialText = (fullText: string) => void;
  * Callback invoked when tool_use or tool_result SSE events arrive.
  * Used by bridge-manager to forward tool progress to adapters for real-time display.
  */
-export type OnToolEvent = (toolId: string, toolName: string, status: 'running' | 'complete' | 'error') => void;
+export type OnToolEvent = (toolId: string, toolName: string, status: 'running' | 'complete' | 'error', input?: Record<string, unknown>) => void;
 
 export interface ConversationResult {
   responseText: string;
@@ -255,7 +255,7 @@ async function consumeStream(
                 input: toolData.input,
               });
               if (onToolEvent) {
-                try { onToolEvent(toolData.id, toolData.name, 'running'); } catch { /* non-critical */ }
+                try { onToolEvent(toolData.id, toolData.name, 'running', toolData.input); } catch { /* non-critical */ }
               }
             } catch { /* skip */ }
             break;

--- a/src/lib/bridge/markdown/feishu.ts
+++ b/src/lib/bridge/markdown/feishu.ts
@@ -99,7 +99,26 @@ export function buildToolProgressMarkdown(tools: ToolCallInfo[]): string {
   if (tools.length === 0) return '';
   const lines = tools.map((tc) => {
     const icon = tc.status === 'running' ? '🔄' : tc.status === 'complete' ? '✅' : '❌';
-    return `${icon} \`${tc.name}\``;
+    let detail = '';
+    if (tc.input) {
+      // Show the most relevant input field per tool
+      const i = tc.input;
+      if (tc.name === 'Bash' && typeof i['command'] === 'string') {
+        const cmd = (i['command'] as string).split('\n')[0].slice(0, 60);
+        detail = ` \`${cmd}${cmd.length < (i['command'] as string).split('\n')[0].length ? '…' : ''}\``;
+      } else if ((tc.name === 'Read' || tc.name === 'Write' || tc.name === 'Edit') && typeof i['file_path'] === 'string') {
+        detail = ` \`${i['file_path']}\``;
+      } else if (tc.name === 'Grep' && typeof i['pattern'] === 'string') {
+        detail = ` \`${i['pattern']}\``;
+      } else if (tc.name === 'Glob' && typeof i['pattern'] === 'string') {
+        detail = ` \`${i['pattern']}\``;
+      } else if (tc.name === 'WebFetch' && typeof i['url'] === 'string') {
+        detail = ` \`${(i['url'] as string).slice(0, 60)}\``;
+      } else if (tc.name === 'WebSearch' && typeof i['query'] === 'string') {
+        detail = ` \`${i['query']}\``;
+      }
+    }
+    return `${icon} **${tc.name}**${detail}`;
   });
   return lines.join('\n');
 }
@@ -121,10 +140,10 @@ export function formatElapsed(ms: number): string {
  * Combines main text content with tool progress.
  */
 export function buildStreamingContent(text: string, tools: ToolCallInfo[]): string {
-  let content = text || '';
+  let content = text ? text.trimEnd() : '';
   const toolMd = buildToolProgressMarkdown(tools);
   if (toolMd) {
-    content = content ? `${content}\n\n${toolMd}` : toolMd;
+    content = content ? `${content}\n\n---\n${toolMd}` : toolMd;
   }
   return content || '💭 Thinking...';
 }
@@ -173,6 +192,10 @@ export function buildFinalCardJson(
   return JSON.stringify({
     schema: '2.0',
     config: { wide_screen_mode: true },
+    header: {
+      title: { tag: 'plain_text', content: '🟢 Answer' },
+      template: 'green',
+    },
     body: { elements },
   });
 }

--- a/src/lib/bridge/types.ts
+++ b/src/lib/bridge/types.ts
@@ -174,6 +174,7 @@ export interface ToolCallInfo {
   id: string;
   name: string;
   status: 'running' | 'complete' | 'error';
+  input?: Record<string, unknown>;
 }
 
 // ── Config ─────────────────────────────────────────────────────


### PR DESCRIPTION
## 问题

`@larksuiteoapi/node-sdk` 实际只提供 `cardkit.v1`，不存在 `v2`，导致所有流式卡片操作时报错：

```
Cannot read properties of undefined (reading 'card')
```

## 修复内容

| 操作 | 修复前 | 修复后 |
|---|---|---|
| 创建卡片 | `cardkit.v2.card.create` | `cardkit.v1.card.create` |
| 流式更新内容 | `cardkit.v2.card.streamContent` | `cardkit.v1.cardElement.content`（需传 `element_id`）|
| 关闭流式模式 | `cardkit.v2.card.settings.streamingMode.set` | `cardkit.v1.card.settings`（`settings` 字段需 JSON 序列化）|
| 最终更新卡片 | `cardkit.v2.card.update` | `cardkit.v1.card.update`（`card` 字段格式为 `{type, data}`）|

- 注册 `im.message.reaction.created_v1` / `deleted_v1` 空处理器，消除无关警告
- 升级 `@larksuiteoapi/node-sdk` 至 1.61.1

🤖 Generated with [Claude Code](https://claude.com/claude-code)