### PR TITLE
fix: apply per-channel system prompt when creating new sessions

### DIFF
--- a/src/lib/bridge/channel-router.ts
+++ b/src/lib/bridge/channel-router.ts
@@ -5,8 +5,27 @@
  * the corresponding ChannelBinding (and underlying chat_session).
  */
 
+import fs from 'fs';
+import os from 'os';
+import path from 'path';
 import type { ChannelAddress, ChannelBinding, ChannelType } from './types.js';
 import { getBridgeContext } from './context.js';
+
+const CTI_HOME = process.env.CTI_HOME || path.join(os.homedir(), '.claude-to-im');
+
+/**
+ * Load a per-channel system prompt from `~/.claude-to-im/<channelType>-persona.md`.
+ * Returns undefined if the file does not exist or is empty.
+ */
+function loadChannelPersona(channelType: string): string | undefined {
+  const file = path.join(CTI_HOME, `${channelType}-persona.md`);
+  try {
+    const content = fs.readFileSync(file, 'utf-8').trim();
+    return content || undefined;
+  } catch {
+    return undefined;
+  }
+}
 
 /**
  * Resolve an inbound address to a ChannelBinding.
@@ -41,10 +60,11 @@ export function createBinding(
   const defaultProviderId = store.getSetting('bridge_default_provider_id') || '';
 
   const displayName = address.displayName || address.chatId;
+  const systemPrompt = loadChannelPersona(address.channelType);
   const session = store.createSession(
     `Bridge: ${displayName}`,
     defaultModel,
-    undefined,
+    systemPrompt,
     defaultCwd,
     'code',
   );


### PR DESCRIPTION
## Problem                                                                                                       
                                                                                                                   
  `createBinding()` unconditionally passes `undefined` as the `systemPrompt`                                       
  argument to `store.createSession()`. As a result, any system prompt                                              
  configured for a session is never populated at creation time, making the                                         
  feature a complete no-op.                                                                                        
                                                                                                                   
  ## Fix                                                                                                           
                                                                                                                   
  Load an optional persona file from `~/.claude-to-im/<channelType>-persona.md`                                    
  (e.g. `feishu-persona.md`, `telegram-persona.md`) at session-creation time
  and pass it as the system prompt. If the file does not exist, behaviour is                                       
  unchanged — no system prompt is set.                                                                             
                                                                                                                   
  The file is read on each `/new` call so changes take effect immediately                                          
  without restarting the bridge.                                                                                   
                                                                                                                   
  ## Testing                                                      
                                                                                                                   
  1. Create `~/.claude-to-im/feishu-persona.md` with any custom instructions                                       
  2. Send `/new` from the corresponding channel
  3. Verify the new session has `system_prompt` set in the store 