### PR TITLE
feat(bridge): add material inbox and Weixin delivery support

### DIFF
--- a/src/__tests__/unit/bridge-delivery-layer.test.ts
+++ b/src/__tests__/unit/bridge-delivery-layer.test.ts
@@ -146,6 +146,33 @@ describe('delivery-layer', () => {
     }
   });
 
+  it('keeps outbound attachments only on the final text chunk', async () => {
+    const sentMessages: OutboundMessage[] = [];
+    const adapter = createMockAdapter({
+      sendFn: async (msg) => {
+        sentMessages.push(msg);
+        return { ok: true, messageId: `msg-${sentMessages.length}` };
+      },
+    });
+
+    const longText = 'Line\n'.repeat(2000);
+    const result = await deliver(adapter, {
+      address: { channelType: 'weixin', chatId: 'wx-chat' },
+      text: longText,
+      parseMode: 'plain',
+      attachments: [
+        { kind: 'video', path: 'D:\\-\\result\\clip.mp4', name: 'clip.mp4', type: 'video/mp4' },
+      ],
+    });
+
+    assert.ok(result.ok);
+    assert.ok(sentMessages.length > 1);
+    assert.equal(sentMessages.slice(0, -1).every((msg) => !msg.attachments), true);
+    assert.deepEqual(sentMessages.at(-1)?.attachments, [
+      { kind: 'video', path: 'D:\\-\\result\\clip.mp4', name: 'clip.mp4', type: 'video/mp4' },
+    ]);
+  });
+
   it('skips delivery when dedup key already exists', async () => {
     store.dedupKeys.add('dedup-1');
     const adapter = createMockAdapter();

--- a/src/__tests__/unit/bridge-material-inbox.test.ts
+++ b/src/__tests__/unit/bridge-material-inbox.test.ts
@@ -1,0 +1,133 @@
+import { afterEach, describe, it } from 'node:test';
+import assert from 'node:assert/strict';
+import fs from 'node:fs';
+import os from 'node:os';
+import path from 'node:path';
+
+import {
+  captureInboxMessage,
+  parseInboxCaptureMessage,
+  resolveInboxStorage,
+} from '../../lib/bridge/material-inbox.js';
+
+const tempDirs: string[] = [];
+
+afterEach(() => {
+  while (tempDirs.length > 0) {
+    const dir = tempDirs.pop();
+    if (dir && fs.existsSync(dir)) {
+      fs.rmSync(dir, { recursive: true, force: true });
+    }
+  }
+});
+
+describe('bridge material inbox parser', () => {
+  it('recognizes phone capture prefixes', () => {
+    assert.deepEqual(parseInboxCaptureMessage('素材：这里是一段素材'), {
+      kind: '素材',
+      rawPrefix: '素材',
+      label: '',
+      body: '这里是一段素材',
+    });
+
+    assert.deepEqual(parseInboxCaptureMessage('灵感 知识库：链接\n为什么存：可以改造个人知识库'), {
+      kind: '灵感',
+      rawPrefix: '灵感 知识库',
+      label: '知识库',
+      body: '链接\n为什么存：可以改造个人知识库',
+    });
+
+    assert.deepEqual(parseInboxCaptureMessage('inbox AI agents: https://x.com/example/status/1'), {
+      kind: 'inbox',
+      rawPrefix: 'inbox AI agents',
+      label: 'AI agents',
+      body: 'https://x.com/example/status/1',
+    });
+  });
+
+  it('ignores normal conversation text', () => {
+    assert.equal(parseInboxCaptureMessage('帮我抓一下今天热点'), null);
+  });
+
+  it('treats bare text as inbox capture only when explicitly allowed', () => {
+    assert.deepEqual(parseInboxCaptureMessage('https://x.com/example/status/1\n为什么存：知识库参考', { allowBare: true }), {
+      kind: 'inbox',
+      rawPrefix: '',
+      label: '',
+      body: 'https://x.com/example/status/1\n为什么存：知识库参考',
+    });
+    assert.equal(parseInboxCaptureMessage('https://x.com/example/status/1', { allowBare: false }), null);
+  });
+});
+
+describe('bridge material inbox storage', () => {
+  it('prefers tech_wechat subdirectories when present', () => {
+    const root = fs.mkdtempSync(path.join(os.tmpdir(), 'bridge-material-'));
+    tempDirs.push(root);
+    fs.mkdirSync(path.join(root, 'tech_wechat'), { recursive: true });
+
+    const resolved = resolveInboxStorage(root);
+
+    assert.equal(resolved.rootDir, path.join(root, 'tech_wechat'));
+    assert.equal(resolved.inboxDir, path.join(root, 'tech_wechat', 'inbox'));
+    assert.equal(resolved.indexFile, path.join(root, 'tech_wechat', 'data', 'bridge-inbox-index.json'));
+  });
+
+  it('appends captures to a daily inbox file and updates the recent index', () => {
+    const root = fs.mkdtempSync(path.join(os.tmpdir(), 'bridge-material-'));
+    tempDirs.push(root);
+    fs.mkdirSync(path.join(root, 'tech_wechat'), { recursive: true });
+
+    const captured = captureInboxMessage({
+      workingDirectory: root,
+      channelType: 'weixin',
+      chatId: 'wx-chat-1',
+      messageId: 'msg-001',
+      timestamp: Date.UTC(2026, 3, 2, 10, 0, 0),
+      displayName: '手机素材',
+      rawText: '灵感 知识库：AI 眼镜不重要，重要的是它开始取代“打开 App”这个动作。\n\n为什么存：可以提醒我关注入口变化。',
+    });
+
+    assert.match(captured.inboxId, /^I20260402-\d{3}$/);
+    assert.equal(captured.relativePath, 'tech_wechat/inbox/2026-04-02.md');
+    assert.equal(fs.existsSync(captured.absolutePath), true);
+
+    const fileText = fs.readFileSync(captured.absolutePath, 'utf8');
+    assert.match(fileText, /# 2026-04-02 微信 Inbox/);
+    assert.match(fileText, /## I20260402-\d{3} · 知识库/);
+    assert.match(fileText, /AI 眼镜不重要/);
+    assert.match(fileText, /来源渠道：weixin/);
+    assert.match(fileText, /状态：待处理/);
+
+    const index = JSON.parse(
+      fs.readFileSync(path.join(root, 'tech_wechat', 'data', 'bridge-inbox-index.json'), 'utf8'),
+    );
+
+    assert.equal(index.version, 1);
+    assert.equal(index.recentByChat['weixin:wx-chat-1'][0].id, captured.inboxId);
+    assert.equal(index.recentByChat['weixin:wx-chat-1'][0].relativePath, captured.relativePath);
+  });
+
+  it('captures bare phone text when allowBare is enabled', () => {
+    const root = fs.mkdtempSync(path.join(os.tmpdir(), 'bridge-material-'));
+    tempDirs.push(root);
+
+    const captured = captureInboxMessage({
+      workingDirectory: root,
+      channelType: 'weixin',
+      chatId: 'wx-chat-1',
+      messageId: 'msg-002',
+      timestamp: Date.UTC(2026, 3, 28, 10, 0, 0),
+      rawText: 'https://mp.weixin.qq.com/s/example\n为什么存：这篇文章可以作为知识库入口设计参考。',
+      allowBare: true,
+    });
+
+    assert.match(captured.inboxId, /^I20260428-\d{3}$/);
+    assert.equal(captured.kind, 'inbox');
+    assert.equal(captured.relativePath, 'inbox/2026-04-28.md');
+
+    const fileText = fs.readFileSync(captured.absolutePath, 'utf8');
+    assert.match(fileText, /https:\/\/mp\.weixin\.qq\.com\/s\/example/);
+    assert.match(fileText, /为什么存：这篇文章可以作为知识库入口设计参考。/);
+  });
+});

--- a/src/__tests__/unit/bridge-weixin-inbox-capture.test.ts
+++ b/src/__tests__/unit/bridge-weixin-inbox-capture.test.ts
@@ -1,0 +1,369 @@
+import { afterEach, describe, it } from 'node:test';
+import assert from 'node:assert/strict';
+import fs from 'node:fs';
+import os from 'node:os';
+import path from 'node:path';
+
+import { initBridgeContext } from '../../lib/bridge/context';
+import type { BaseChannelAdapter } from '../../lib/bridge/channel-adapter';
+import type { BridgeStore } from '../../lib/bridge/host';
+import type { ChannelBinding, OutboundMessage, SendResult } from '../../lib/bridge/types';
+
+const tempDirs: string[] = [];
+
+afterEach(() => {
+  delete (globalThis as Record<string, unknown>)['__bridge_context__'];
+  delete (globalThis as Record<string, unknown>)['__bridge_manager__'];
+
+  while (tempDirs.length > 0) {
+    const dir = tempDirs.pop();
+    if (dir && fs.existsSync(dir)) {
+      fs.rmSync(dir, { recursive: true, force: true });
+    }
+  }
+});
+
+describe('bridge-manager weixin inbox capture', () => {
+  it('captures ordinary WeChat text into inbox without invoking the LLM', async () => {
+    const root = fs.mkdtempSync(path.join(os.tmpdir(), 'bridge-weixin-inbox-'));
+    tempDirs.push(root);
+
+    const sentMessages: OutboundMessage[] = [];
+    const storedMessages: Array<{ role: string; content: string }> = [];
+    let llmInvoked = false;
+
+    initBridgeContext({
+      store: createInboxStore(root, storedMessages) as unknown as BridgeStore,
+      llm: {
+        streamChat: () => {
+          llmInvoked = true;
+          throw new Error('LLM should not be invoked for inbox captures');
+        },
+      },
+      permissions: { resolvePendingPermission: () => false },
+      lifecycle: {},
+    });
+
+    const { _testOnly } = await import('../../lib/bridge/bridge-manager');
+    await _testOnly.handleMessage(createWeixinAdapter(sentMessages), {
+      messageId: 'wx-msg-1',
+      address: { channelType: 'weixin', chatId: 'wx-chat-1', userId: 'wx-user-1', displayName: '手机' },
+      text: 'https://x.com/example/status/1\n为什么存：这个适合放进个人知识库。',
+      timestamp: Date.UTC(2026, 3, 28, 10, 0, 0),
+    });
+
+    assert.equal(llmInvoked, false);
+    assert.equal(sentMessages.length, 1);
+    assert.match(sentMessages[0].text, /已存入 Inbox I20260428-001/);
+
+    const inboxFile = path.join(root, 'inbox', '2026-04-28.md');
+    assert.equal(fs.existsSync(inboxFile), true);
+    const inboxText = fs.readFileSync(inboxFile, 'utf8');
+    assert.match(inboxText, /https:\/\/x\.com\/example\/status\/1/);
+    assert.match(inboxText, /状态：待处理/);
+
+    assert.equal(storedMessages.length, 2);
+    assert.match(storedMessages[0].content, /\[手机 inbox\] ID=I20260428-001/);
+  });
+  it('routes WeChat text to Codex remote controller when enabled without writing legacy inbox', async () => {
+    const root = fs.mkdtempSync(path.join(os.tmpdir(), 'bridge-weixin-cwrc-'));
+    tempDirs.push(root);
+
+    const adapterPath = path.join(root, 'mock-wechat-adapter.mjs');
+    fs.writeFileSync(adapterPath, `
+export function createWeChatMessageHandler(options = {}) {
+  globalThis.__cwrcOptions = options;
+  return async function handleWeChatMessage(message) {
+    globalThis.__cwrcCalls = [...(globalThis.__cwrcCalls || []), message];
+    return { text: 'CWRC:' + message.content, response: { reply: 'CWRC:' + message.content } };
+  };
+}
+`, 'utf8');
+    (globalThis as Record<string, unknown>).__cwrcCalls = [];
+
+    const sentMessages: OutboundMessage[] = [];
+    const storedMessages: Array<{ role: string; content: string }> = [];
+    let llmInvoked = false;
+
+    initBridgeContext({
+      store: createInboxStore(root, storedMessages, {
+        bridge_weixin_codex_controller_enabled: 'true',
+        bridge_weixin_codex_controller_path: adapterPath,
+        bridge_weixin_codex_workspace_root: root,
+      }) as unknown as BridgeStore,
+      llm: {
+        streamChat: () => {
+          llmInvoked = true;
+          throw new Error('LLM should not be invoked for Codex remote controller messages');
+        },
+      },
+      permissions: { resolvePendingPermission: () => false },
+      lifecycle: {},
+    });
+
+    const { _testOnly } = await import('../../lib/bridge/bridge-manager');
+    await _testOnly.handleMessage(createWeixinAdapter(sentMessages), {
+      messageId: 'wx-msg-cwrc-1',
+      address: { channelType: 'weixin', chatId: 'wx-chat-1', userId: 'wx-user-1', displayName: '手机' },
+      text: '列表',
+      timestamp: Date.UTC(2026, 4, 8, 13, 0, 0),
+    });
+
+    assert.equal(llmInvoked, false);
+    assert.equal(sentMessages.length, 1);
+    assert.equal(sentMessages[0].text, 'CWRC:列表');
+    const cwrcCalls = (globalThis as Record<string, unknown>).__cwrcCalls as Array<Record<string, unknown>>;
+    assert.equal(typeof cwrcCalls[0].sendReply, 'function');
+    delete cwrcCalls[0].sendReply;
+    assert.deepEqual(cwrcCalls, [{
+      chatId: 'wx-chat-1',
+      content: '列表',
+      createTime: Date.UTC(2026, 4, 8, 13, 0, 0),
+      fromUserName: 'wx-user-1',
+      id: 'wx-msg-cwrc-1',
+    }]);
+    assert.equal(fs.existsSync(path.join(root, 'inbox', '2026-05-08.md')), false);
+    assert.equal(storedMessages.length, 0);
+  });
+
+  it('passes an async reply callback to the Codex remote controller', async () => {
+    const root = fs.mkdtempSync(path.join(os.tmpdir(), 'bridge-weixin-cwrc-callback-'));
+    tempDirs.push(root);
+
+    const adapterPath = path.join(root, 'mock-wechat-adapter.mjs');
+    fs.writeFileSync(adapterPath, `
+export function createWeChatMessageHandler() {
+  return async function handleWeChatMessage(message) {
+    globalThis.__cwrcCalls = [...(globalThis.__cwrcCalls || []), {
+      hasSendReply: typeof message.sendReply === 'function',
+    }];
+    message.sendReply('CWRC async:' + message.content);
+    return { text: 'CWRC accepted:' + message.content };
+  };
+}
+`, 'utf8');
+    (globalThis as Record<string, unknown>).__cwrcCalls = [];
+
+    const sentMessages: OutboundMessage[] = [];
+    const storedMessages: Array<{ role: string; content: string }> = [];
+
+    initBridgeContext({
+      store: createInboxStore(root, storedMessages, {
+        bridge_weixin_codex_controller_enabled: 'true',
+        bridge_weixin_codex_controller_path: adapterPath,
+        bridge_weixin_codex_workspace_root: root,
+      }) as unknown as BridgeStore,
+      llm: {
+        streamChat: () => {
+          throw new Error('LLM should not be invoked for Codex remote controller messages');
+        },
+      },
+      permissions: { resolvePendingPermission: () => false },
+      lifecycle: {},
+    });
+
+    const { _testOnly } = await import('../../lib/bridge/bridge-manager');
+    await _testOnly.handleMessage(createWeixinAdapter(sentMessages), {
+      messageId: 'wx-msg-cwrc-callback-1',
+      address: { channelType: 'weixin', chatId: 'wx-chat-1', userId: 'wx-user-1', displayName: '鎵嬫満' },
+      text: '鍒楄〃',
+      timestamp: Date.UTC(2026, 4, 8, 13, 0, 0),
+    });
+    await new Promise(resolve => setImmediate(resolve));
+
+    assert.deepEqual((globalThis as Record<string, unknown>).__cwrcCalls, [{ hasSendReply: true }]);
+    assert.equal(sentMessages.length, 2);
+    assert.deepEqual(sentMessages.map(message => message.text).sort(), [
+      'CWRC accepted:鍒楄〃',
+      'CWRC async:鍒楄〃',
+    ].sort());
+  });
+
+  it('propagates Codex remote controller attachments to WeChat outbound messages', async () => {
+    const root = fs.mkdtempSync(path.join(os.tmpdir(), 'bridge-weixin-cwrc-attachments-'));
+    tempDirs.push(root);
+
+    const artifactPath = path.join(root, 'clip.mp4');
+    fs.writeFileSync(artifactPath, 'fake video', 'utf8');
+    const adapterPath = path.join(root, 'mock-wechat-adapter.mjs');
+    fs.writeFileSync(adapterPath, `
+export function createWeChatMessageHandler() {
+  return async function handleWeChatMessage() {
+    return {
+      text: '成品如下：clip.mp4',
+      attachments: [
+        { kind: 'video', path: ${JSON.stringify(artifactPath)}, name: 'clip.mp4', type: 'video/mp4' },
+      ],
+    };
+  };
+}
+`, 'utf8');
+
+    const sentMessages: OutboundMessage[] = [];
+    const storedMessages: Array<{ role: string; content: string }> = [];
+
+    initBridgeContext({
+      store: createInboxStore(root, storedMessages, {
+        bridge_weixin_codex_controller_enabled: 'true',
+        bridge_weixin_codex_controller_path: adapterPath,
+        bridge_weixin_codex_workspace_root: root,
+      }) as unknown as BridgeStore,
+      llm: {
+        streamChat: () => {
+          throw new Error('LLM should not be invoked for Codex remote controller messages');
+        },
+      },
+      permissions: { resolvePendingPermission: () => false },
+      lifecycle: {},
+    });
+
+    const { _testOnly } = await import('../../lib/bridge/bridge-manager');
+    await _testOnly.handleMessage(createWeixinAdapter(sentMessages), {
+      messageId: 'wx-msg-cwrc-attachment-1',
+      address: { channelType: 'weixin', chatId: 'wx-chat-1', userId: 'wx-user-1', displayName: '手机' },
+      text: '把视频发给我',
+      timestamp: Date.UTC(2026, 4, 8, 13, 0, 0),
+    });
+
+    assert.equal(sentMessages.length, 1);
+    assert.equal(sentMessages[0].text, '成品如下：clip.mp4');
+    assert.deepEqual(sentMessages[0].attachments, [
+      { kind: 'video', path: artifactPath, name: 'clip.mp4', type: 'video/mp4' },
+    ]);
+  });
+
+  it('does not send a WeChat reply when the Codex remote controller marks output silent', async () => {
+    const root = fs.mkdtempSync(path.join(os.tmpdir(), 'bridge-weixin-cwrc-silent-'));
+    tempDirs.push(root);
+
+    const adapterPath = path.join(root, 'mock-wechat-adapter.mjs');
+    fs.writeFileSync(adapterPath, `
+export function createWeChatMessageHandler() {
+  return async function handleWeChatMessage(message) {
+    globalThis.__cwrcCalls = [...(globalThis.__cwrcCalls || []), message];
+    return { silent: true, text: '', response: { reply: '', silent: true } };
+  };
+}
+`, 'utf8');
+    (globalThis as Record<string, unknown>).__cwrcCalls = [];
+
+    const sentMessages: OutboundMessage[] = [];
+    const storedMessages: Array<{ role: string; content: string }> = [];
+    let llmInvoked = false;
+
+    initBridgeContext({
+      store: createInboxStore(root, storedMessages, {
+        bridge_weixin_codex_controller_enabled: 'true',
+        bridge_weixin_codex_controller_path: adapterPath,
+        bridge_weixin_codex_workspace_root: root,
+      }) as unknown as BridgeStore,
+      llm: {
+        streamChat: () => {
+          llmInvoked = true;
+          throw new Error('LLM should not be invoked for silent Codex remote controller messages');
+        },
+      },
+      permissions: { resolvePendingPermission: () => false },
+      lifecycle: {},
+    });
+
+    const { _testOnly } = await import('../../lib/bridge/bridge-manager');
+    await _testOnly.handleMessage(createWeixinAdapter(sentMessages), {
+      messageId: 'wx-msg-cwrc-silent-1',
+      address: { channelType: 'weixin', chatId: 'wx-chat-1', userId: 'wx-user-1', displayName: '手机' },
+      text: '知识库：只沉淀不回复',
+      timestamp: Date.UTC(2026, 4, 8, 13, 0, 0),
+    });
+
+    assert.equal(llmInvoked, false);
+    assert.equal(sentMessages.length, 0);
+    const cwrcCalls = (globalThis as Record<string, unknown>).__cwrcCalls as Array<Record<string, unknown>>;
+    assert.equal(typeof cwrcCalls[0].sendReply, 'function');
+    delete cwrcCalls[0].sendReply;
+    assert.deepEqual(cwrcCalls, [{
+      chatId: 'wx-chat-1',
+      content: '知识库：只沉淀不回复',
+      createTime: Date.UTC(2026, 4, 8, 13, 0, 0),
+      fromUserName: 'wx-user-1',
+      id: 'wx-msg-cwrc-silent-1',
+    }]);
+    assert.equal(fs.existsSync(path.join(root, 'inbox', '2026-05-08.md')), false);
+    assert.equal(storedMessages.length, 0);
+  });
+});
+
+function createWeixinAdapter(sentMessages: OutboundMessage[]): BaseChannelAdapter {
+  return {
+    channelType: 'weixin',
+    start: async () => {},
+    stop: async () => {},
+    isRunning: () => true,
+    consumeOne: async () => null,
+    send: async (msg: OutboundMessage): Promise<SendResult> => {
+      sentMessages.push(msg);
+      return { ok: true, messageId: 'reply-1' };
+    },
+    validateConfig: () => null,
+    isAuthorized: () => true,
+  } as unknown as BaseChannelAdapter;
+}
+
+function createInboxStore(
+  workingDirectory: string,
+  storedMessages: Array<{ role: string; content: string }>,
+  settings: Record<string, string> = {},
+) {
+  const auditLogs: unknown[] = [];
+  const dedupKeys = new Set<string>();
+
+  return {
+    auditLogs,
+    getSetting: (key: string) => {
+      if (key in settings) return settings[key];
+      return key === 'bridge_default_work_dir' ? workingDirectory : null;
+    },
+    getChannelBinding: () => null,
+    upsertChannelBinding: (binding: Partial<ChannelBinding>) => ({
+      id: 'binding-1',
+      channelType: binding.channelType || 'weixin',
+      chatId: binding.chatId || 'wx-chat-1',
+      codepilotSessionId: binding.codepilotSessionId || 'session-1',
+      sdkSessionId: binding.sdkSessionId || '',
+      workingDirectory: binding.workingDirectory || workingDirectory,
+      model: binding.model || '',
+      mode: binding.mode || 'code',
+      active: true,
+      createdAt: new Date(0).toISOString(),
+      updatedAt: new Date(0).toISOString(),
+    }),
+    updateChannelBinding: () => {},
+    listChannelBindings: () => [],
+    getSession: () => null,
+    createSession: () => ({ id: 'session-1', working_directory: workingDirectory, model: '' }),
+    updateSessionProviderId: () => {},
+    addMessage: (_sessionId: string, role: string, content: string) => {
+      storedMessages.push({ role, content });
+    },
+    getMessages: () => ({ messages: [] }),
+    acquireSessionLock: () => true,
+    renewSessionLock: () => {},
+    releaseSessionLock: () => {},
+    setSessionRuntimeStatus: () => {},
+    updateSdkSessionId: () => {},
+    updateSessionModel: () => {},
+    syncSdkTasks: () => {},
+    getProvider: () => undefined,
+    getDefaultProviderId: () => null,
+    insertAuditLog: (entry: unknown) => { auditLogs.push(entry); },
+    checkDedup: (key: string) => dedupKeys.has(key),
+    insertDedup: (key: string) => { dedupKeys.add(key); },
+    cleanupExpiredDedup: () => {},
+    insertOutboundRef: () => {},
+    insertPermissionLink: () => {},
+    getPermissionLink: () => null,
+    markPermissionLinkResolved: () => false,
+    listPendingPermissionLinksByChat: () => [],
+    getChannelOffset: () => '0',
+    setChannelOffset: () => {},
+  };
+}

--- a/src/__tests__/unit/bridge-weixin-markdown.test.ts
+++ b/src/__tests__/unit/bridge-weixin-markdown.test.ts
@@ -1,0 +1,24 @@
+import { describe, it } from 'node:test';
+import assert from 'node:assert/strict';
+
+import { markdownToWeixinText } from '../../lib/bridge/markdown/weixin';
+
+describe('bridge weixin markdown renderer', () => {
+  it('renders markdown tables as readable bullet lists', () => {
+    const rendered = markdownToWeixinText(`
+| 项目 | 评分 | 链接 |
+| --- | --- | --- |
+| DeepSeek R2 | 45 | [项目主页](https://example.com/deepseek-r2) |
+`);
+
+    assert.match(rendered, /【DeepSeek R2】/);
+    assert.match(rendered, /- 评分: 45/);
+    assert.match(rendered, /- 链接: 项目主页 \(https:\/\/example\.com\/deepseek-r2\)/);
+  });
+
+  it('keeps bare URLs visible without duplicating them', () => {
+    const rendered = markdownToWeixinText('文档地址：https://example.com/docs');
+
+    assert.equal(rendered, '文档地址：https://example.com/docs');
+  });
+});

--- a/src/lib/bridge/adapters/feishu-adapter.ts
+++ b/src/lib/bridge/adapters/feishu-adapter.ts
@@ -48,7 +48,7 @@ const MAX_FILE_SIZE = 20 * 1024 * 1024;
 /** Feishu emoji type for typing indicator (same as Openclaw). */
 const TYPING_EMOJI = 'Typing';
 
-/** State for an active CardKit v2 streaming card. */
+/** State for an active streaming card. */
 interface FeishuCardState {
   cardId: string;
   messageId: string;
@@ -63,6 +63,9 @@ interface FeishuCardState {
 
 /** Streaming card throttle interval (ms). */
 const CARD_THROTTLE_MS = 200;
+
+/** Card element id used for incremental content updates. */
+const STREAMING_ELEMENT_ID = 'streaming_content';
 
 /** Shape of the SDK's im.message.receive_v1 event data. */
 type FeishuMessageEventData = {
@@ -374,7 +377,13 @@ export class FeishuAdapter extends BaseChannelAdapter {
     if (!this.restClient) return false;
 
     try {
-      // Step 1: Create card via CardKit v2
+      const cardkit = (this.restClient as any).cardkit?.v1;
+      if (!cardkit?.card) {
+        console.warn('[feishu-adapter] CardKit v1 client unavailable');
+        return false;
+      }
+
+      // Step 1: Create card via CardKit
       const cardBody = {
         schema: '2.0',
         config: {
@@ -388,12 +397,12 @@ export class FeishuAdapter extends BaseChannelAdapter {
             content: '💭 Thinking...',
             text_align: 'left',
             text_size: 'normal',
-            element_id: 'streaming_content',
+            element_id: STREAMING_ELEMENT_ID,
           }],
         },
       };
 
-      const createResp = await (this.restClient as any).cardkit.v2.card.create({
+      const createResp = await cardkit.card.create({
         data: { type: 'card_json', data: JSON.stringify(cardBody) },
       });
       const cardId = createResp?.data?.card_id;
@@ -488,6 +497,9 @@ export class FeishuAdapter extends BaseChannelAdapter {
     const state = this.activeCards.get(chatId);
     if (!state || !this.restClient) return;
 
+    const cardkit = (this.restClient as any).cardkit?.v1;
+    if (!cardkit?.cardElement) return;
+
     const content = buildStreamingContent(state.pendingText || '', state.toolCalls);
 
     state.sequence++;
@@ -495,13 +507,13 @@ export class FeishuAdapter extends BaseChannelAdapter {
     const cardId = state.cardId;
 
     // Fire-and-forget — streaming updates are non-critical
-    (this.restClient as any).cardkit.v2.card.streamContent({
-      path: { card_id: cardId },
+    cardkit.cardElement.content({
+      path: { card_id: cardId, element_id: STREAMING_ELEMENT_ID },
       data: { content, sequence: seq },
     }).then(() => {
       state.lastUpdateAt = Date.now();
     }).catch((err: unknown) => {
-      console.warn('[feishu-adapter] streamContent failed:', err instanceof Error ? err.message : err);
+      console.warn('[feishu-adapter] cardElement.content failed:', err instanceof Error ? err.message : err);
     });
   }
 
@@ -540,12 +552,25 @@ export class FeishuAdapter extends BaseChannelAdapter {
     }
 
     try {
-      // Step 1: Close streaming mode
+      const cardkit = (this.restClient as any).cardkit?.v1;
+      if (!cardkit?.card) {
+        console.warn('[feishu-adapter] CardKit v1 client unavailable during finalize');
+        return false;
+      }
+
+      // Step 1: Best-effort close streaming mode
       state.sequence++;
-      await (this.restClient as any).cardkit.v2.card.settings.streamingMode.set({
-        path: { card_id: state.cardId },
-        data: { streaming_mode: false, sequence: state.sequence },
-      });
+      try {
+        await cardkit.card.settings({
+          path: { card_id: state.cardId },
+          data: {
+            settings: JSON.stringify({ streaming_mode: false }),
+            sequence: state.sequence,
+          },
+        });
+      } catch (err) {
+        console.warn('[feishu-adapter] Card settings finalize step failed:', err instanceof Error ? err.message : err);
+      }
 
       // Step 2: Build and apply final card
       const statusLabels: Record<string, string> = {
@@ -562,9 +587,12 @@ export class FeishuAdapter extends BaseChannelAdapter {
       const finalCardJson = buildFinalCardJson(responseText, state.toolCalls, footer);
 
       state.sequence++;
-      await (this.restClient as any).cardkit.v2.card.update({
+      await cardkit.card.update({
         path: { card_id: state.cardId },
-        data: { type: 'card_json', data: finalCardJson, sequence: state.sequence },
+        data: {
+          card: { type: 'card_json', data: finalCardJson },
+          sequence: state.sequence,
+        },
       });
 
       console.log(`[feishu-adapter] Card finalized: cardId=${state.cardId}, status=${status}, elapsed=${formatElapsed(elapsedMs)}`);

--- a/src/lib/bridge/bridge-manager.ts
+++ b/src/lib/bridge/bridge-manager.ts
@@ -7,7 +7,10 @@
  * Uses globalThis to survive Next.js HMR in development.
  */
 
-import type { BridgeStatus, InboundMessage, OutboundMessage, StreamingPreviewState, ToolCallInfo } from './types.js';
+import type { BridgeStatus, InboundMessage, OutboundAttachment, OutboundMessage, StreamingPreviewState, ToolCallInfo } from './types.js';
+import fs from 'node:fs';
+import path from 'node:path';
+import { pathToFileURL } from 'node:url';
 import { createAdapter, getRegisteredTypes } from './channel-adapter.js';
 import type { BaseChannelAdapter } from './channel-adapter.js';
 // Side-effect import: triggers self-registration of all adapter factories
@@ -18,6 +21,8 @@ import * as broker from './permission-broker.js';
 import { deliver, deliverRendered } from './delivery-layer.js';
 import { markdownToTelegramChunks } from './markdown/telegram.js';
 import { markdownToDiscordChunks } from './markdown/discord.js';
+import { markdownToWeixinText } from './markdown/weixin.js';
+import { captureInboxMessage, parseInboxCaptureMessage } from './material-inbox.js';
 import { getBridgeContext } from './context.js';
 import { escapeHtml } from './adapters/telegram-utils.js';
 import {
@@ -27,8 +32,18 @@ import {
   sanitizeInput,
   validateMode,
 } from './security/validators.js';
+import type { FileAttachment } from './host.js';
 
 const GLOBAL_KEY = '__bridge_manager__';
+
+type CodexRemoteHandler = (message: Record<string, unknown>) => Promise<{
+  attachments?: OutboundAttachment[];
+  silent?: boolean;
+  text?: string;
+  response?: { attachments?: OutboundAttachment[]; reply?: string; silent?: boolean };
+}>;
+
+const codexRemoteHandlerCache = new Map<string, Promise<CodexRemoteHandler>>();
 
 // ── Streaming preview helpers ──────────────────────────────────
 
@@ -146,6 +161,14 @@ async function deliverResponse(
       replyToMessageId,
     }, { sessionId });
   }
+  if (adapter.channelType === 'weixin') {
+    return deliver(adapter, {
+      address,
+      text: markdownToWeixinText(responseText),
+      parseMode: 'plain',
+      replyToMessageId,
+    }, { sessionId });
+  }
   // Generic fallback: deliver as plain text (deliver() handles chunking internally)
   return deliver(adapter, {
     address,
@@ -153,6 +176,148 @@ async function deliverResponse(
     parseMode: 'plain',
     replyToMessageId,
   }, { sessionId });
+}
+
+function getCodexRemoteWorkspaceRoot(): string {
+  const { store } = getBridgeContext();
+  return store.getSetting('bridge_weixin_codex_workspace_root')
+    || store.getSetting('bridge_default_work_dir')
+    || process.env.CWRC_WORKSPACE_ROOT
+    || process.cwd();
+}
+
+function getCodexRemoteAdapterPath(): string {
+  const { store } = getBridgeContext();
+  const configured = store.getSetting('bridge_weixin_codex_controller_path')
+    || process.env.CWRC_WECHAT_ADAPTER_PATH;
+
+  if (configured) {
+    return path.resolve(configured);
+  }
+
+  return path.join(
+    getCodexRemoteWorkspaceRoot(),
+    'Projects_Services',
+    'Project_Codex_Wechat_Remote_Controller',
+    'src',
+    'wechat-adapter.mjs',
+  );
+}
+
+function getCodexRemoteHandler(): Promise<CodexRemoteHandler> {
+  const adapterPath = getCodexRemoteAdapterPath();
+  const workspaceRoot = getCodexRemoteWorkspaceRoot();
+  const cacheKey = `${adapterPath}|${workspaceRoot}`;
+
+  if (!codexRemoteHandlerCache.has(cacheKey)) {
+    const handlerPromise = loadCodexRemoteHandler(adapterPath, workspaceRoot).catch(err => {
+      codexRemoteHandlerCache.delete(cacheKey);
+      throw err;
+    });
+    codexRemoteHandlerCache.set(cacheKey, handlerPromise);
+  }
+
+  return codexRemoteHandlerCache.get(cacheKey)!;
+}
+
+async function loadCodexRemoteHandler(adapterPath: string, workspaceRoot: string): Promise<CodexRemoteHandler> {
+  if (!fs.existsSync(adapterPath)) {
+    throw new Error(`Codex remote controller adapter not found: ${adapterPath}`);
+  }
+
+  const module = await import(pathToFileURL(adapterPath).href) as {
+    createWeChatMessageHandler?: (options?: Record<string, unknown>) => CodexRemoteHandler;
+  };
+
+  if (typeof module.createWeChatMessageHandler !== 'function') {
+    throw new Error(`Codex remote controller adapter does not export createWeChatMessageHandler: ${adapterPath}`);
+  }
+
+  return module.createWeChatMessageHandler({ config: { workspaceRoot } });
+}
+
+async function handleWeixinCodexRemoteController(
+  adapter: BaseChannelAdapter,
+  msg: InboundMessage,
+  rawText: string,
+): Promise<void> {
+  const { store } = getBridgeContext();
+  const handler = await getCodexRemoteHandler();
+  const sendReply = async (text: unknown) => {
+    const normalizedReply = normalizeCodexRemoteReply(text);
+    const replyText = normalizedReply.text;
+    if (!replyText && !normalizedReply.attachments?.length) return;
+    await deliver(adapter, {
+      address: msg.address,
+      text: replyText,
+      parseMode: 'plain',
+      replyToMessageId: msg.messageId,
+      attachments: normalizedReply.attachments,
+    });
+  };
+  const output = await handler({
+    chatId: msg.address.chatId,
+    content: rawText,
+    createTime: msg.timestamp,
+    fromUserName: msg.address.userId || msg.address.chatId,
+    id: msg.messageId,
+    sendReply,
+  });
+  const reply = normalizeCodexRemoteReply(output);
+  const silent = output.silent === true || output.response?.silent === true;
+
+  store.insertAuditLog({
+    channelType: adapter.channelType,
+    chatId: msg.address.chatId,
+    direction: 'inbound',
+    messageId: msg.messageId,
+    summary: `[CWRC] ${rawText.slice(0, 200)}`,
+  });
+
+  if (silent) {
+    store.insertAuditLog({
+      channelType: adapter.channelType,
+      chatId: msg.address.chatId,
+      direction: 'outbound',
+      messageId: msg.messageId,
+      summary: '[CWRC_SILENT] reply suppressed',
+    });
+    return;
+  }
+
+  await sendReply(reply.text || reply.attachments?.length
+    ? reply
+    : 'Codex remote controller returned an empty reply.');
+}
+
+function normalizeCodexRemoteReply(payload: unknown): { text: string; attachments?: OutboundAttachment[] } {
+  if (typeof payload === 'string') {
+    return { text: payload };
+  }
+  if (!payload || typeof payload !== 'object') {
+    return { text: String(payload ?? '') };
+  }
+
+  const record = payload as {
+    attachments?: unknown;
+    reply?: unknown;
+    response?: { attachments?: unknown; reply?: unknown };
+    text?: unknown;
+  };
+  const text = typeof record.text === 'string'
+    ? record.text
+    : typeof record.reply === 'string'
+      ? record.reply
+      : typeof record.response?.reply === 'string'
+        ? record.response.reply
+        : '';
+  const attachments = Array.isArray(record.attachments)
+    ? record.attachments as OutboundAttachment[]
+    : Array.isArray(record.response?.attachments)
+      ? record.response.attachments as OutboundAttachment[]
+      : undefined;
+
+  return { text, attachments };
 }
 
 interface AdapterMeta {
@@ -557,8 +722,8 @@ async function handleMessage(
         return;
       }
       // pendingLinks.length === 0: no pending permissions, fall through as normal message
-    } else if (rawText !== normalized && /^[123]$/.test(rawText) === false) {
-      // Log when normalization changed the text — helps diagnose encoding issues
+    } else if (rawText !== normalized && /^[１２３1-3\u200B-\u200D\uFEFF\s]+$/u.test(rawText)) {
+      // Log only numeric shortcut candidates changed by normalization.
       const codePoints = [...rawText].map(c => 'U+' + c.codePointAt(0)!.toString(16).toUpperCase().padStart(4, '0'));
       console.log(`[bridge-manager] Shortcut candidate raw codepoints: ${codePoints.join(' ')} → normalized: "${normalized}"`);
     }
@@ -567,6 +732,113 @@ async function handleMessage(
   // Check for IM commands (before sanitization — commands are validated individually)
   if (rawText.startsWith('/')) {
     await handleCommand(adapter, msg, rawText);
+    ack();
+    return;
+  }
+
+  if (
+    adapter.channelType === 'weixin'
+    && !hasAttachments
+    && store.getSetting('bridge_weixin_codex_controller_enabled') === 'true'
+  ) {
+    try {
+      await handleWeixinCodexRemoteController(adapter, msg, rawText);
+    } catch (err) {
+      const errorMessage = err instanceof Error ? err.message : String(err);
+      store.insertAuditLog({
+        channelType: adapter.channelType,
+        chatId: msg.address.chatId,
+        direction: 'inbound',
+        messageId: msg.messageId,
+        summary: `[CWRC_ERROR] ${errorMessage}`,
+      });
+      await deliver(adapter, {
+        address: msg.address,
+        text: `Codex remote controller failed: ${errorMessage}`,
+        parseMode: 'plain',
+        replyToMessageId: msg.messageId,
+      });
+    }
+    ack();
+    return;
+  }
+
+  const inboxRawText = adapter.channelType === 'weixin'
+    ? buildInboxCaptureRawText(rawText, msg.attachments)
+    : rawText;
+  const inboxPayload = parseInboxCaptureMessage(inboxRawText, { allowBare: adapter.channelType === 'weixin' });
+  if (inboxPayload) {
+    const binding = router.resolve(msg.address);
+
+    if (!inboxPayload.body) {
+      await deliver(adapter, {
+        address: msg.address,
+        text: '已识别为 inbox 捕捉，但内容为空。请使用“灵感：内容”或“素材：内容”格式发送。',
+        parseMode: 'plain',
+        replyToMessageId: msg.messageId,
+      }, { sessionId: binding.codepilotSessionId });
+      ack();
+      return;
+    }
+
+    try {
+      const captured = captureInboxMessage({
+        workingDirectory: binding.workingDirectory,
+        channelType: adapter.channelType,
+        chatId: msg.address.chatId,
+        messageId: msg.messageId,
+        timestamp: msg.timestamp,
+        displayName: msg.address.displayName,
+        rawText: inboxRawText,
+        allowBare: adapter.channelType === 'weixin',
+      });
+
+      store.insertAuditLog({
+        channelType: adapter.channelType,
+        chatId: msg.address.chatId,
+        direction: 'inbound',
+        messageId: msg.messageId,
+        summary: `[INBOX] ${captured.inboxId} ${captured.relativePath}`,
+      });
+
+      store.addMessage(
+        binding.codepilotSessionId,
+        'user',
+        [
+          `[手机 inbox] ID=${captured.inboxId}`,
+          `入口=${captured.kind}`,
+          `标签=${captured.label || '无'}`,
+          `路径=${captured.relativePath}`,
+          `摘要=${captured.preview}`,
+        ].join('；'),
+      );
+      store.addMessage(
+        binding.codepilotSessionId,
+        'assistant',
+        `已存入 inbox ${captured.inboxId}。电脑打开后可核验、整理，再决定是否进入 raw/wiki/projects。`,
+      );
+
+      await deliver(adapter, {
+        address: msg.address,
+        text: [
+          `已存入 Inbox ${captured.inboxId}`,
+          `路径：${captured.relativePath}`,
+          `摘要：${captured.preview}`,
+          '电脑打开后可统一核验，再整理进 raw / wiki / projects。',
+        ].join('\n'),
+        parseMode: 'plain',
+        replyToMessageId: msg.messageId,
+      }, { sessionId: binding.codepilotSessionId });
+    } catch (err) {
+      const errorMessage = err instanceof Error ? err.message : String(err);
+      await deliver(adapter, {
+        address: msg.address,
+        text: `Inbox 入库失败：${errorMessage}`,
+        parseMode: 'plain',
+        replyToMessageId: msg.messageId,
+      }, { sessionId: binding.codepilotSessionId });
+    }
+
     ack();
     return;
   }
@@ -725,7 +997,43 @@ async function handleMessage(
     // Skip if streaming card was finalized (content already in card).
     if (result.responseText) {
       if (!cardFinalized) {
-        await deliverResponse(adapter, msg.address, result.responseText, binding.codepilotSessionId, msg.messageId);
+        const deliveryResult = await deliverResponse(
+          adapter,
+          msg.address,
+          result.responseText,
+          binding.codepilotSessionId,
+          msg.messageId,
+        );
+        if (!deliveryResult.ok) {
+          console.warn(
+            '[bridge-manager] Final response delivery failed:',
+            JSON.stringify({
+              channelType: adapter.channelType,
+              chatId: msg.address.chatId,
+              sessionId: binding.codepilotSessionId,
+              error: deliveryResult.error ?? 'unknown',
+            }),
+          );
+
+          const noticeResult = await deliver(adapter, {
+            address: msg.address,
+            text: '结果已经生成，但回传消息失败了。你可以回复“重发简版”，我会用更短的格式再发一次。',
+            parseMode: 'plain',
+            replyToMessageId: msg.messageId,
+          }, { sessionId: binding.codepilotSessionId });
+
+          if (!noticeResult.ok) {
+            console.warn(
+              '[bridge-manager] Delivery failure notice also failed:',
+              JSON.stringify({
+                channelType: adapter.channelType,
+                chatId: msg.address.chatId,
+                sessionId: binding.codepilotSessionId,
+                error: noticeResult.error ?? 'unknown',
+              }),
+            );
+          }
+        }
       }
     } else if (result.hasError) {
       const errorResponse: OutboundMessage = {
@@ -771,6 +1079,31 @@ async function handleMessage(
     // Commit the offset only after full processing (success or failure)
     ack();
   }
+}
+
+function buildInboxCaptureRawText(rawText: string, attachments?: FileAttachment[]): string {
+  const parts: string[] = [];
+  const trimmedText = rawText.trim();
+  if (trimmedText) {
+    parts.push(trimmedText);
+  }
+
+  if (attachments?.length) {
+    parts.push([
+      '附件：',
+      ...attachments.map((attachment, index) => {
+        const fields = [
+          `${index + 1}. ${attachment.name || attachment.id || '未命名附件'}`,
+          `类型=${attachment.type || 'unknown'}`,
+          `大小=${attachment.size ?? 0} bytes`,
+          attachment.filePath ? `路径=${attachment.filePath}` : '',
+        ].filter(Boolean);
+        return `- ${fields.join('；')}`;
+      }),
+    ].join('\n'));
+  }
+
+  return parts.join('\n\n');
 }
 
 /**

--- a/src/lib/bridge/delivery-layer.ts
+++ b/src/lib/bridge/delivery-layer.ts
@@ -185,6 +185,8 @@ export async function deliver(
       text: chunks[i],
       // Only attach inline buttons to the last chunk
       inlineButtons: i === chunks.length - 1 ? message.inlineButtons : undefined,
+      // Only attach files/media to the last chunk so uploads are not duplicated.
+      attachments: i === chunks.length - 1 ? message.attachments : undefined,
       // Pass through replyToMessageId for platforms that need it (e.g. QQ passive reply)
       replyToMessageId: message.replyToMessageId,
     };
@@ -239,7 +241,15 @@ async function sendWithRetry(
   let lastError: string | undefined;
 
   for (let attempt = 0; attempt < MAX_RETRIES; attempt++) {
-    const result = await adapter.send(message);
+    let result: SendResult;
+    try {
+      result = await adapter.send(message);
+    } catch (err) {
+      result = {
+        ok: false,
+        error: err instanceof Error ? err.message : String(err),
+      };
+    }
     if (result.ok) return result;
 
     lastError = result.error;

--- a/src/lib/bridge/markdown/feishu.ts
+++ b/src/lib/bridge/markdown/feishu.ts
@@ -172,7 +172,10 @@ export function buildFinalCardJson(
 
   return JSON.stringify({
     schema: '2.0',
-    config: { wide_screen_mode: true },
+    config: {
+      wide_screen_mode: true,
+      streaming_mode: false,
+    },
     body: { elements },
   });
 }

--- a/src/lib/bridge/markdown/ir.ts
+++ b/src/lib/bridge/markdown/ir.ts
@@ -79,6 +79,7 @@ type RenderState = RenderTarget & {
   env: RenderEnv;
   headingStyle: 'none' | 'bold';
   blockquotePrefix: string;
+  tableStyle: 'code' | 'bullets';
   table: TableState | null;
 };
 
@@ -88,6 +89,7 @@ export type MarkdownParseOptions = {
   blockquotePrefix?: string;
   autolink?: boolean;
   enableTables?: boolean;
+  tableStyle?: 'code' | 'bullets';
 };
 
 function createMarkdownIt(options: MarkdownParseOptions): MarkdownIt {
@@ -322,13 +324,9 @@ function renderTableAsBullets(state: RenderState) {
 
       const rowLabel = row[0];
       if (rowLabel?.text) {
-        const labelStart = state.text.length;
+        state.text += '【';
         appendCell(state, rowLabel);
-        const labelEnd = state.text.length;
-        if (labelEnd > labelStart) {
-          state.styles.push({ start: labelStart, end: labelEnd, style: 'bold' });
-        }
-        state.text += '\n';
+        state.text += '】\n';
       }
 
       for (let i = 1; i < row.length; i++) {
@@ -337,7 +335,7 @@ function renderTableAsBullets(state: RenderState) {
         if (!value?.text) {
           continue;
         }
-        state.text += '• ';
+        state.text += '- ';
         if (header?.text) {
           appendCell(state, header);
           state.text += ': ';
@@ -357,7 +355,7 @@ function renderTableAsBullets(state: RenderState) {
         if (!value?.text) {
           continue;
         }
-        state.text += '• ';
+        state.text += '- ';
         if (header?.text) {
           appendCell(state, header);
           state.text += ': ';
@@ -572,7 +570,11 @@ function renderTokens(tokens: MarkdownToken[], state: RenderState): void {
         break;
       case 'table_close':
         if (state.table) {
-          renderTableAsCode(state);
+          if (state.tableStyle === 'bullets') {
+            renderTableAsBullets(state);
+          } else {
+            renderTableAsCode(state);
+          }
         }
         state.table = null;
         break;
@@ -766,6 +768,7 @@ export function markdownToIR(markdown: string, options: MarkdownParseOptions = {
     env,
     headingStyle: options.headingStyle ?? 'none',
     blockquotePrefix: options.blockquotePrefix ?? '',
+    tableStyle: options.tableStyle ?? 'code',
     table: null,
   };
 

--- a/src/lib/bridge/markdown/weixin.ts
+++ b/src/lib/bridge/markdown/weixin.ts
@@ -1,0 +1,125 @@
+import { markdownToIR, type MarkdownLinkSpan } from './ir.js';
+
+function isTableRow(line: string): boolean {
+  const trimmed = line.trim();
+  if (!trimmed) {
+    return false;
+  }
+  if (/^\|(?:\s*:?-+:?\s*\|)+\s*$/.test(trimmed)) {
+    return true;
+  }
+  return /^\|.+\|\s*$/.test(trimmed);
+}
+
+function normalizeLooseTables(markdown: string): string {
+  const lines = markdown.replace(/\r\n/g, '\n').split('\n');
+  const normalized: string[] = [];
+
+  for (let i = 0; i < lines.length; i += 1) {
+    const line = lines[i] ?? '';
+    if (line.trim() !== '') {
+      normalized.push(line);
+      continue;
+    }
+
+    const previous = normalized[normalized.length - 1] ?? '';
+    let nextNonEmpty = '';
+    for (let j = i + 1; j < lines.length; j += 1) {
+      if (lines[j]?.trim()) {
+        nextNonEmpty = lines[j] ?? '';
+        break;
+      }
+    }
+
+    if (isTableRow(previous) && isTableRow(nextNonEmpty)) {
+      continue;
+    }
+
+    normalized.push(line);
+  }
+
+  return normalized.join('\n');
+}
+
+function normalizeVisibleUrl(value: string): string {
+  return value
+    .trim()
+    .replace(/^<|>$/g, '')
+    .replace(/^https?:\/\//i, '')
+    .replace(/\/+$/g, '')
+    .toLowerCase();
+}
+
+function labelAlreadyShowsHref(label: string, href: string): boolean {
+  const normalizedLabel = normalizeVisibleUrl(label);
+  const normalizedHref = normalizeVisibleUrl(href);
+  if (!normalizedLabel || !normalizedHref) {
+    return false;
+  }
+  return normalizedLabel === normalizedHref || normalizedLabel.includes(normalizedHref);
+}
+
+function formatVisibleLink(label: string, href: string): string {
+  if (labelAlreadyShowsHref(label, href)) {
+    return '';
+  }
+  return label.includes('\n') ? `\n链接: ${href}` : ` (${href})`;
+}
+
+function injectVisibleLinks(text: string, links: MarkdownLinkSpan[]): string {
+  if (!text || links.length === 0) {
+    return text;
+  }
+
+  const sorted = [...links].toSorted((a, b) => {
+    if (a.start !== b.start) {
+      return a.start - b.start;
+    }
+    return a.end - b.end;
+  });
+
+  let output = '';
+  let cursor = 0;
+
+  for (const link of sorted) {
+    const start = Math.max(0, Math.min(link.start, text.length));
+    const end = Math.max(start, Math.min(link.end, text.length));
+    if (end <= cursor) {
+      continue;
+    }
+
+    output += text.slice(cursor, start);
+    const label = text.slice(start, end);
+    output += label;
+
+    const href = link.href.trim();
+    if (href) {
+      output += formatVisibleLink(label, href);
+    }
+
+    cursor = end;
+  }
+
+  output += text.slice(cursor);
+  return output;
+}
+
+function normalizeWeixinText(text: string): string {
+  return text
+    .replace(/\r\n/g, '\n')
+    .replace(/[ \t]+\n/g, '\n')
+    .replace(/\n{3,}/g, '\n\n')
+    .replace(/^[\u2500-\u257f\u2014-]{3,}$/gm, '------')
+    .trim();
+}
+
+export function markdownToWeixinText(markdown: string): string {
+  const ir = markdownToIR(normalizeLooseTables(markdown), {
+    enableTables: true,
+    tableStyle: 'bullets',
+    blockquotePrefix: '引用: ',
+  });
+
+  const withVisibleLinks = injectVisibleLinks(ir.text, ir.links);
+  return normalizeWeixinText(withVisibleLinks);
+}

--- a/src/lib/bridge/material-inbox.ts
+++ b/src/lib/bridge/material-inbox.ts
@@ -1,0 +1,279 @@
+import fs from 'node:fs';
+import path from 'node:path';
+
+export interface ParsedInboxCaptureMessage {
+  kind: string;
+  rawPrefix: string;
+  label: string;
+  body: string;
+}
+
+export type ParsedMaterialMessage = ParsedInboxCaptureMessage;
+
+export interface InboxStoragePaths {
+  rootDir: string;
+  inboxDir: string;
+  dataDir: string;
+  indexFile: string;
+}
+
+export interface MaterialStoragePaths extends InboxStoragePaths {
+  rawDir: string;
+}
+
+export interface CaptureInboxMessageInput {
+  workingDirectory: string;
+  channelType: string;
+  chatId: string;
+  messageId: string;
+  timestamp: number;
+  displayName?: string;
+  rawText: string;
+  allowBare?: boolean;
+}
+
+export type CaptureMaterialMessageInput = CaptureInboxMessageInput;
+
+export interface InboxCaptureResult {
+  inboxId: string;
+  absolutePath: string;
+  relativePath: string;
+  preview: string;
+  kind: string;
+  label: string;
+  capturedAt: string;
+}
+
+export interface MaterialCaptureResult extends InboxCaptureResult {
+  materialId: string;
+}
+
+interface InboxIndexEntry {
+  id: string;
+  kind: string;
+  label: string;
+  relativePath: string;
+  preview: string;
+  capturedAt: string;
+  messageId: string;
+  channelType: string;
+}
+
+interface InboxIndexFile {
+  version: 1;
+  nextSequenceByDay: Record<string, number>;
+  recentByChat: Record<string, InboxIndexEntry[]>;
+}
+
+const INBOX_PREFIX_RE = /^\s*((素材|灵感|收件箱|inbox)[^:：\n]{0,40})[:：]\s*([\s\S]*)$/iu;
+const MAX_RECENT_PER_CHAT = 20;
+
+export function parseInboxCaptureMessage(
+  rawText: string,
+  options: { allowBare?: boolean } = {},
+): ParsedInboxCaptureMessage | null {
+  const match = INBOX_PREFIX_RE.exec(rawText);
+  if (!match) {
+    const body = rawText.trim();
+    if (!options.allowBare || !body) return null;
+    return {
+      kind: 'inbox',
+      rawPrefix: '',
+      label: '',
+      body,
+    };
+  }
+
+  const rawPrefix = match[1].trim();
+  const rawKind = match[2].trim();
+  const kind = rawKind.toLowerCase() === 'inbox' ? 'inbox' : rawKind;
+  const label = rawPrefix.slice(rawKind.length).trim().replace(/^[-_\s]+|[-_\s]+$/g, '');
+  const body = match[3].trim();
+
+  return {
+    kind,
+    rawPrefix,
+    label,
+    body,
+  };
+}
+
+export function parseMaterialMessage(rawText: string): ParsedMaterialMessage | null {
+  return parseInboxCaptureMessage(rawText);
+}
+
+export function resolveInboxStorage(workingDirectory: string): InboxStoragePaths {
+  const techWechatRoot = path.join(workingDirectory, 'tech_wechat');
+  const rootDir = fs.existsSync(techWechatRoot) ? techWechatRoot : workingDirectory;
+  const inboxDir = path.join(rootDir, 'inbox');
+  const dataDir = path.join(rootDir, 'data');
+
+  return {
+    rootDir,
+    inboxDir,
+    dataDir,
+    indexFile: path.join(dataDir, 'bridge-inbox-index.json'),
+  };
+}
+
+export function resolveMaterialStorage(workingDirectory: string): MaterialStoragePaths {
+  const storage = resolveInboxStorage(workingDirectory);
+  return {
+    ...storage,
+    rawDir: storage.inboxDir,
+  };
+}
+
+export function captureInboxMessage(input: CaptureInboxMessageInput): InboxCaptureResult {
+  const parsed = parseInboxCaptureMessage(input.rawText, { allowBare: input.allowBare });
+  if (!parsed) {
+    throw new Error('Message is not an inbox capture payload.');
+  }
+  if (!parsed.body) {
+    throw new Error('Inbox capture payload is empty.');
+  }
+
+  const capturedAt = new Date(input.timestamp).toISOString();
+  const storage = resolveInboxStorage(input.workingDirectory);
+  const dayStamp = capturedAt.slice(0, 10);
+  const dayKey = dayStamp.replace(/-/g, '');
+  const index = loadIndex(storage.indexFile);
+  const nextSeq = index.nextSequenceByDay[dayKey] ?? 1;
+
+  index.nextSequenceByDay[dayKey] = nextSeq + 1;
+
+  const inboxId = `I${dayKey}-${String(nextSeq).padStart(3, '0')}`;
+  const preview = buildPreview(parsed.body);
+  const absolutePath = path.join(storage.inboxDir, `${dayStamp}.md`);
+  const relativePath = normalizeRelativePath(path.relative(input.workingDirectory, absolutePath));
+
+  ensureDir(storage.inboxDir);
+  ensureDir(storage.dataDir);
+
+  appendInboxEntry(absolutePath, dayStamp, {
+    inboxId,
+    capturedAt,
+    channelType: input.channelType,
+    chatId: input.chatId,
+    messageId: input.messageId,
+    displayName: input.displayName || '',
+    kind: parsed.kind,
+    label: parsed.label,
+    relativePath,
+    body: parsed.body,
+  });
+
+  const chatKey = `${input.channelType}:${input.chatId}`;
+  const recentEntry: InboxIndexEntry = {
+    id: inboxId,
+    kind: parsed.kind,
+    label: parsed.label,
+    relativePath,
+    preview,
+    capturedAt,
+    messageId: input.messageId,
+    channelType: input.channelType,
+  };
+  const currentRecent = index.recentByChat[chatKey] ?? [];
+  index.recentByChat[chatKey] = [recentEntry, ...currentRecent].slice(0, MAX_RECENT_PER_CHAT);
+  fs.writeFileSync(storage.indexFile, JSON.stringify(index, null, 2), 'utf8');
+
+  return {
+    inboxId,
+    absolutePath,
+    relativePath,
+    preview,
+    kind: parsed.kind,
+    label: parsed.label,
+    capturedAt,
+  };
+}
+
+export function captureMaterialMessage(input: CaptureMaterialMessageInput): MaterialCaptureResult {
+  const result = captureInboxMessage(input);
+  return {
+    ...result,
+    materialId: result.inboxId,
+  };
+}
+
+function loadIndex(indexFile: string): InboxIndexFile {
+  if (!fs.existsSync(indexFile)) {
+    return {
+      version: 1,
+      nextSequenceByDay: {},
+      recentByChat: {},
+    };
+  }
+
+  try {
+    const parsed = JSON.parse(fs.readFileSync(indexFile, 'utf8')) as Partial<InboxIndexFile>;
+    return {
+      version: 1,
+      nextSequenceByDay: parsed.nextSequenceByDay ?? {},
+      recentByChat: parsed.recentByChat ?? {},
+    };
+  } catch {
+    return {
+      version: 1,
+      nextSequenceByDay: {},
+      recentByChat: {},
+    };
+  }
+}
+
+function ensureDir(dirPath: string): void {
+  if (!fs.existsSync(dirPath)) {
+    fs.mkdirSync(dirPath, { recursive: true });
+  }
+}
+
+function normalizeRelativePath(relativePath: string): string {
+  return relativePath.split(path.sep).join('/');
+}
+
+function buildPreview(text: string): string {
+  const normalized = text.replace(/\s+/g, ' ').trim();
+  if (normalized.length <= 120) return normalized;
+  return `${normalized.slice(0, 117)}...`;
+}
+
+interface InboxEntryInput {
+  inboxId: string;
+  capturedAt: string;
+  channelType: string;
+  chatId: string;
+  messageId: string;
+  displayName: string;
+  kind: string;
+  label: string;
+  relativePath: string;
+  body: string;
+}
+
+function appendInboxEntry(absolutePath: string, dayStamp: string, input: InboxEntryInput): void {
+  const hasFile = fs.existsSync(absolutePath) && fs.statSync(absolutePath).size > 0;
+  const displayLabel = input.label || input.kind;
+  const header = hasFile ? '' : `# ${dayStamp} 微信 Inbox\n`;
+  const entry = [
+    header,
+    `## ${input.inboxId} · ${displayLabel}`,
+    '',
+    `- 捕获时间：${input.capturedAt}`,
+    `- 来源渠道：${input.channelType}`,
+    `- chatId：${input.chatId}`,
+    `- 来源消息：${input.messageId}`,
+    `- 来源显示名：${input.displayName}`,
+    `- 捕捉入口：${input.kind}`,
+    `- 标签：${input.label || '无'}`,
+    `- 状态：待处理`,
+    `- 相对路径：${input.relativePath}`,
+    '',
+    '### 原始内容',
+    '',
+    input.body,
+    '',
+  ].filter((line, index) => index !== 0 || line !== '').join('\n');
+
+  fs.appendFileSync(absolutePath, `${hasFile ? '\n\n' : ''}${entry}`, 'utf8');
+}

--- a/src/lib/bridge/types.ts
+++ b/src/lib/bridge/types.ts
@@ -57,6 +57,24 @@ export interface InboundMessage {
 }
 
 /** Outbound message to send to an IM channel */
+export interface OutboundAttachment {
+  /** Attachment kind; channels may infer this from type/name if omitted. */
+  kind?: 'file' | 'video' | 'image';
+  /** Local filesystem path for artifacts produced on this computer. */
+  path?: string;
+  /** Alias used by some bridge components. */
+  filePath?: string;
+  /** Display filename. */
+  name?: string;
+  /** MIME type. */
+  type?: string;
+  /** Byte size when known. */
+  size?: number;
+  /** Base64 data for in-memory attachments. */
+  data?: string;
+}
+
+/** Outbound message to send to an IM channel */
 export interface OutboundMessage {
   /** Target address */
   address: ChannelAddress;
@@ -68,6 +86,8 @@ export interface OutboundMessage {
   inlineButtons?: InlineButton[][];
   /** If replying to a specific message */
   replyToMessageId?: string;
+  /** Files or media to send after the text body */
+  attachments?: OutboundAttachment[];
 }
 
 /** Inline keyboard button for permission prompts */


### PR DESCRIPTION
- add a durable material inbox and Weixin inbox capture path;
- add Weixin Markdown rendering and shared IR support;
- improve Feishu delivery integration and bridge-manager routing;
- add focused delivery, material-inbox, and Weixin unit coverage.

Testing:
- npm run typecheck
- npm run test:unit (77/77)